### PR TITLE
feature/larpandoracontent_v03_23_03

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ else()
     foreach(PROJ IN LISTS PROJECT_NAME DL_PROJECT_NAME)
         set(${PROJ}_VERSION_MAJOR 03)
         set(${PROJ}_VERSION_MINOR 23)
-        set(${PROJ}_VERSION_PATCH 02)
+        set(${PROJ}_VERSION_PATCH 03)
         set(${PROJ}_VERSION "${${PROJ}_VERSION_MAJOR}.${${PROJ}_VERSION_MINOR}.${${PROJ}_VERSION_PATCH}")
     endforeach()
 

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,11 @@
 --------------------------------------------------------------------------------------------------------------------------------------------
+TAG v03_23_03
+--------------------------------------------------------------------------------------------------------------------------------------------
+Add tools for matching reconstructed and true hierarchies
+Add algorithm to clean up 3D hits to support iterative shower growing
+Fix issue when building without PandoraMonitoring
+
+--------------------------------------------------------------------------------------------------------------------------------------------
 TAG v03_23_02
 --------------------------------------------------------------------------------------------------------------------------------------------
 Updated MVA vertex selection to provide for energy deposition asymmetry and feature sharing between two vertex candidates

--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -198,6 +198,7 @@
 #include "larpandoracontent/LArUtility/ListDeletionAlgorithm.h"
 #include "larpandoracontent/LArUtility/ListMergingAlgorithm.h"
 #include "larpandoracontent/LArUtility/ListPruningAlgorithm.h"
+#include "larpandoracontent/LArUtility/PfoHitCleaningAlgorithm.h"
 
 #include "larpandoracontent/LArVertex/CandidateVertexCreationAlgorithm.h"
 #include "larpandoracontent/LArVertex/EnergyKickVertexSelectionAlgorithm.h"
@@ -304,6 +305,7 @@
     d("LArListChanging",                        ListChangingAlgorithm)                                                          \
     d("LArListDeletion",                        ListDeletionAlgorithm)                                                          \
     d("LArListMerging",                         ListMergingAlgorithm)                                                           \
+    d("LArPfoHitCleaning",                      PfoHitCleaningAlgorithm)                                                        \
     d("LArListPruning",                         ListPruningAlgorithm)                                                           \
     d("LArCandidateVertexCreation",             CandidateVertexCreationAlgorithm)                                               \
     d("LArEnergyKickVertexSelection",           EnergyKickVertexSelectionAlgorithm)                                             \

--- a/larpandoracontent/LArHelpers/LArHierarchyHelper.cc
+++ b/larpandoracontent/LArHelpers/LArHierarchyHelper.cc
@@ -1,0 +1,1091 @@
+/**
+ *  @file   larpandoracontent/LArHelpers/LArHierarchyHelper.cc
+ *
+ *  @brief  Implementation of the lar hierarchy helper class.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/PdgTable.h"
+#include "Pandora/StatusCodes.h"
+
+#include "larpandoracontent/LArHelpers/LArHierarchyHelper.h"
+
+#include <numeric>
+
+namespace lar_content
+{
+
+using namespace pandora;
+
+LArHierarchyHelper::MCHierarchy::MCHierarchy(const ReconstructabilityCriteria &recoCriteria) :
+    m_recoCriteria(recoCriteria),
+    m_pNeutrino{nullptr}
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::MCHierarchy::~MCHierarchy()
+{
+    for (const Node *pNode : m_rootNodes)
+        delete pNode;
+    m_rootNodes.clear();
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::MCHierarchy::FillHierarchy(
+    const MCParticleList &mcParticleList, const CaloHitList &caloHitList, const bool foldToPrimaries, const bool foldToLeadingShowers)
+{
+    const auto predicate = [](const MCParticle *pMCParticle) { return std::abs(pMCParticle->GetParticleId()) == NEUTRON; };
+    m_mcToHitsMap.clear();
+    for (const CaloHit *pCaloHit : caloHitList)
+    {
+        try
+        {
+            const MCParticle *pMCParticle{MCParticleHelper::GetMainMCParticle(pCaloHit)};
+            m_mcToHitsMap[pMCParticle].emplace_back(pCaloHit);
+        }
+        catch (const StatusCodeException &)
+        {
+        }
+    }
+
+    MCParticleSet primarySet;
+    m_pNeutrino = LArHierarchyHelper::GetMCPrimaries(mcParticleList, primarySet);
+    MCParticleList primaries(primarySet.begin(), primarySet.end());
+    primaries.sort(LArMCParticleHelper::SortByMomentum);
+    if (m_recoCriteria.m_removeNeutrons)
+        primaries.erase(std::remove_if(primaries.begin(), primaries.end(), predicate), primaries.end());
+    if (foldToPrimaries && !foldToLeadingShowers)
+    {
+        for (const MCParticle *pPrimary : primaries)
+        {
+            MCParticleList allParticles{pPrimary};
+            if (!m_recoCriteria.m_removeNeutrons)
+            {
+                LArMCParticleHelper::GetAllDescendentMCParticles(pPrimary, allParticles);
+            }
+            else
+            {
+                // Collect track-like and shower-like particles together, but throw out neutrons and descendents
+                MCParticleList dummy;
+                LArMCParticleHelper::GetAllDescendentMCParticles(pPrimary, allParticles, allParticles, dummy);
+            }
+            CaloHitList allHits;
+            for (const MCParticle *pMCParticle : allParticles)
+            {
+                // Not all MC particles will have hits
+                if (m_mcToHitsMap.find(pMCParticle) != m_mcToHitsMap.end())
+                {
+                    const CaloHitList &caloHits(m_mcToHitsMap.at(pMCParticle));
+                    allHits.insert(allHits.begin(), caloHits.begin(), caloHits.end());
+                }
+            }
+            m_rootNodes.emplace_back(new Node(*this, allParticles, allHits));
+        }
+    }
+    else if (foldToPrimaries && foldToLeadingShowers)
+    {
+        for (const MCParticle *pPrimary : primaries)
+        {
+            MCParticleList allParticles{pPrimary}, showerParticles, neutrons;
+            int pdg{std::abs(pPrimary->GetParticleId())};
+            const bool isShower{pdg == E_MINUS || pdg == PHOTON};
+            const bool isNeutron{pdg == NEUTRON};
+            if (isShower || isNeutron)
+            {
+                if (!m_recoCriteria.m_removeNeutrons)
+                {
+                    LArMCParticleHelper::GetAllDescendentMCParticles(pPrimary, allParticles);
+                }
+                else
+                {
+                    // Throw away neutrons
+                    MCParticleList dummy;
+                    LArMCParticleHelper::GetAllDescendentMCParticles(pPrimary, allParticles, allParticles, dummy);
+                }
+            }
+            else
+            {
+                LArMCParticleHelper::GetAllDescendentMCParticles(pPrimary, allParticles, showerParticles, neutrons);
+            }
+            CaloHitList allHits;
+            for (const MCParticle *pMCParticle : allParticles)
+            {
+                // ATTN - Not all MC particles will have hits
+                if (m_mcToHitsMap.find(pMCParticle) != m_mcToHitsMap.end())
+                {
+                    const CaloHitList &caloHits(m_mcToHitsMap.at(pMCParticle));
+                    allHits.insert(allHits.begin(), caloHits.begin(), caloHits.end());
+                }
+            }
+            Node *pNode{new Node(*this, allParticles, allHits)};
+            m_rootNodes.emplace_back(pNode);
+            if (!showerParticles.empty())
+            {
+                // Collect up all descendent hits for each shower and add the nodes as a child of the root node
+                for (const MCParticle *pChild : showerParticles)
+                    pNode->FillFlat(pChild);
+            }
+            if (!m_recoCriteria.m_removeNeutrons && !neutrons.empty())
+            {
+                // Collect up all descendent hits for each neutron and add the nodes as a child of the root node
+                for (const MCParticle *pChild : neutrons)
+                    pNode->FillFlat(pChild);
+            }
+        }
+    }
+    else if (foldToLeadingShowers)
+    {
+        for (const MCParticle *pPrimary : primaries)
+        {
+            MCParticleList allParticles{pPrimary};
+            int pdg{std::abs(pPrimary->GetParticleId())};
+            const bool isShower{pdg == E_MINUS || pdg == PHOTON};
+            const bool isNeutron{pdg == NEUTRON};
+            if (isShower || (isNeutron && !m_recoCriteria.m_removeNeutrons))
+                LArMCParticleHelper::GetAllDescendentMCParticles(pPrimary, allParticles);
+            CaloHitList allHits;
+            for (const MCParticle *pMCParticle : allParticles)
+            {
+                // ATTN - Not all MC particles will have hits
+                if (m_mcToHitsMap.find(pMCParticle) != m_mcToHitsMap.end())
+                {
+                    const CaloHitList &caloHits(m_mcToHitsMap.at(pMCParticle));
+                    allHits.insert(allHits.begin(), caloHits.begin(), caloHits.end());
+                }
+            }
+            Node *pNode{new Node(*this, allParticles, allHits)};
+            m_rootNodes.emplace_back(pNode);
+            if (!(isShower || isNeutron))
+            {
+                // Find the children of this particle and recursively add them to the hierarchy
+                const MCParticleList &children{pPrimary->GetDaughterList()};
+                for (const MCParticle *pChild : children)
+                    pNode->FillHierarchy(pChild, foldToLeadingShowers);
+            }
+        }
+    }
+    else
+    {
+        for (const MCParticle *pPrimary : primaries)
+        {
+            MCParticleList allParticles{pPrimary};
+            CaloHitList allHits;
+            for (const MCParticle *pMCParticle : allParticles)
+            {
+                // ATTN - Not all MC particles will have hits
+                if (m_mcToHitsMap.find(pMCParticle) != m_mcToHitsMap.end())
+                {
+                    const CaloHitList &caloHits(m_mcToHitsMap.at(pMCParticle));
+                    allHits.insert(allHits.begin(), caloHits.begin(), caloHits.end());
+                }
+            }
+            Node *pNode{new Node(*this, allParticles, allHits)};
+            m_rootNodes.emplace_back(pNode);
+            // Find the children of this particle and recursively add them to the hierarchy
+            const MCParticleList &children{pPrimary->GetDaughterList()};
+            for (const MCParticle *pChild : children)
+                pNode->FillHierarchy(pChild, foldToLeadingShowers);
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::MCHierarchy::GetFlattenedNodes(NodeVector &nodeVector) const
+{
+    NodeList queue;
+    for (const Node *pNode : m_rootNodes)
+    {
+        nodeVector.emplace_back(pNode);
+        queue.emplace_back(pNode);
+    }
+    while (!queue.empty())
+    {
+        const NodeVector &children{queue.front()->GetChildren()};
+        queue.pop_front();
+        for (const Node *pChild : children)
+        {
+            nodeVector.emplace_back(pChild);
+            queue.emplace_back(pChild);
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const std::string LArHierarchyHelper::MCHierarchy::ToString() const
+{
+    std::string str;
+    for (const Node *pNode : m_rootNodes)
+        str += pNode->ToString("") + "\n";
+
+    return str;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::MCHierarchy::Node::Node(const MCHierarchy &hierarchy, const MCParticle *pMCParticle) :
+    m_hierarchy(hierarchy),
+    m_mainParticle(pMCParticle),
+    m_pdg{0}
+{
+    if (pMCParticle)
+    {
+        m_pdg = pMCParticle->GetParticleId();
+        m_mcParticles.emplace_back(pMCParticle);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::MCHierarchy::Node::Node(const MCHierarchy &hierarchy, const MCParticleList &mcParticleList, const CaloHitList &caloHitList) :
+    m_hierarchy(hierarchy),
+    m_mcParticles(mcParticleList),
+    m_caloHits(caloHitList),
+    m_mainParticle(nullptr),
+    m_pdg{0}
+{
+    if (!mcParticleList.empty())
+    {
+        m_mainParticle = mcParticleList.front();
+        m_pdg = m_mainParticle->GetParticleId();
+    }
+    m_mcParticles.sort(LArMCParticleHelper::SortByMomentum);
+    m_caloHits.sort();
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::MCHierarchy::Node::~Node()
+{
+    m_mcParticles.clear();
+    m_caloHits.clear();
+    for (const Node *node : m_children)
+        delete node;
+    m_children.clear();
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::MCHierarchy::Node::FillHierarchy(const MCParticle *pRoot, const bool foldToLeadingShowers)
+{
+    MCParticleList allParticles{pRoot};
+    const int pdg{std::abs(pRoot->GetParticleId())};
+    const bool isShower{pdg == E_MINUS || pdg == PHOTON};
+    const bool isNeutron{pdg == NEUTRON};
+    if (foldToLeadingShowers && (isShower || (isNeutron && !m_hierarchy.m_recoCriteria.m_removeNeutrons)))
+        LArMCParticleHelper::GetAllDescendentMCParticles(pRoot, allParticles);
+    else if (m_hierarchy.m_recoCriteria.m_removeNeutrons && isNeutron)
+        return;
+
+    CaloHitList allHits;
+    for (const MCParticle *pMCParticle : allParticles)
+    {
+        // ATTN - Not all MC particles will have hits
+        if (m_hierarchy.m_mcToHitsMap.find(pMCParticle) != m_hierarchy.m_mcToHitsMap.end())
+        {
+            const CaloHitList &caloHits(m_hierarchy.m_mcToHitsMap.at(pMCParticle));
+            allHits.insert(allHits.begin(), caloHits.begin(), caloHits.end());
+        }
+    }
+
+    if (!allParticles.empty())
+    {
+        Node *pNode{new Node(m_hierarchy, allParticles, allHits)};
+        m_children.emplace_back(pNode);
+        if (!foldToLeadingShowers || (foldToLeadingShowers && !(isShower || isNeutron)))
+        {
+            // Find the children of this particle and recursively add them to the hierarchy
+            const MCParticleList &children{pRoot->GetDaughterList()};
+            for (const MCParticle *pChild : children)
+                pNode->FillHierarchy(pChild, foldToLeadingShowers);
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::MCHierarchy::Node::FillFlat(const MCParticle *pRoot)
+{
+    MCParticleList allParticles{pRoot};
+    if (!m_hierarchy.m_recoCriteria.m_removeNeutrons)
+    {
+        LArMCParticleHelper::GetAllDescendentMCParticles(pRoot, allParticles);
+    }
+    else
+    {
+        MCParticleList neutrons;
+        LArMCParticleHelper::GetAllDescendentMCParticles(pRoot, allParticles, allParticles, neutrons);
+    }
+    CaloHitList allHits;
+    for (const MCParticle *pMCParticle : allParticles)
+    {
+        // ATTN - Not all MC particles will have hits
+        if (m_hierarchy.m_mcToHitsMap.find(pMCParticle) != m_hierarchy.m_mcToHitsMap.end())
+        {
+            const CaloHitList &caloHits(m_hierarchy.m_mcToHitsMap.at(pMCParticle));
+            allHits.insert(allHits.begin(), caloHits.begin(), caloHits.end());
+        }
+    }
+    if (!allParticles.empty())
+    {
+        Node *pNode{new Node(m_hierarchy, allParticles, allHits)};
+        m_children.emplace_back(pNode);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool LArHierarchyHelper::MCHierarchy::Node::IsReconstructable() const
+{
+    const bool enoughHits{m_caloHits.size() >= m_hierarchy.m_recoCriteria.m_minHits};
+    if (!enoughHits)
+        return false;
+    bool enoughGoodViews{false};
+    unsigned int nHitsU{0}, nHitsV{0}, nHitsW{0};
+    for (const CaloHit *pCaloHit : m_caloHits)
+    {
+        switch (pCaloHit->GetHitType())
+        {
+            case TPC_VIEW_U:
+                ++nHitsU;
+                break;
+            case TPC_VIEW_V:
+                ++nHitsV;
+                break;
+            case TPC_VIEW_W:
+                ++nHitsW;
+                break;
+            default:
+                break;
+        }
+        unsigned int nGoodViews{0};
+        if (nHitsU >= m_hierarchy.m_recoCriteria.m_minHitsForGoodView)
+            ++nGoodViews;
+        if (nHitsV >= m_hierarchy.m_recoCriteria.m_minHitsForGoodView)
+            ++nGoodViews;
+        if (nHitsW >= m_hierarchy.m_recoCriteria.m_minHitsForGoodView)
+            ++nGoodViews;
+        if (nGoodViews >= m_hierarchy.m_recoCriteria.m_minGoodViews)
+        {
+            enoughGoodViews = true;
+            break;
+        }
+    }
+
+    return enoughGoodViews;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool LArHierarchyHelper::MCHierarchy::Node::IsTestBeamParticle() const
+{
+    if (m_mainParticle)
+        return LArMCParticleHelper::IsBeamParticle(m_mainParticle);
+    else
+        return false;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool LArHierarchyHelper::MCHierarchy::Node::IsCosmicRay() const
+{
+    if (m_mainParticle)
+        return LArMCParticleHelper::IsCosmicRay(m_mainParticle);
+    else
+        return false;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const std::string LArHierarchyHelper::MCHierarchy::Node::ToString(const std::string &prefix) const
+{
+    std::string str(prefix + "PDG: " + std::to_string(m_pdg) + " Energy: " + std::to_string(m_mainParticle ? m_mainParticle->GetEnergy() : 0) +
+                    " Hits: " + std::to_string(m_caloHits.size()) + "\n");
+    for (const Node *pChild : m_children)
+        str += pChild->ToString(prefix + "   ");
+
+    return str;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::MCHierarchy::ReconstructabilityCriteria::ReconstructabilityCriteria() :
+    m_minHits{15},
+    m_minHitsForGoodView{5},
+    m_minGoodViews{2},
+    m_removeNeutrons{true}
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::MCHierarchy::ReconstructabilityCriteria::ReconstructabilityCriteria(const ReconstructabilityCriteria &obj) :
+    m_minHits{obj.m_minHits},
+    m_minHitsForGoodView{obj.m_minHitsForGoodView},
+    m_minGoodViews{obj.m_minGoodViews},
+    m_removeNeutrons{obj.m_removeNeutrons}
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::MCHierarchy::ReconstructabilityCriteria::ReconstructabilityCriteria(
+    const unsigned int minHits, const unsigned int minHitsForGoodView, const unsigned int minGoodViews, const bool removeNeutrons) :
+    m_minHits{minHits},
+    m_minHitsForGoodView{minHitsForGoodView},
+    m_minGoodViews{minGoodViews},
+    m_removeNeutrons{removeNeutrons}
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::RecoHierarchy::RecoHierarchy() : m_pNeutrino{nullptr}
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::RecoHierarchy::~RecoHierarchy()
+{
+    for (const Node *pNode : m_rootNodes)
+        delete pNode;
+    m_rootNodes.clear();
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::RecoHierarchy::FillHierarchy(const PfoList &pfoList, const bool foldToPrimaries, const bool foldToLeadingShowers)
+{
+    PfoSet primarySet;
+    m_pNeutrino = LArHierarchyHelper::GetRecoPrimaries(pfoList, primarySet);
+    PfoList primaries(primarySet.begin(), primarySet.end());
+    primaries.sort(LArPfoHelper::SortByNHits);
+    if (foldToPrimaries && !foldToLeadingShowers)
+    {
+        for (const ParticleFlowObject *pPrimary : primaries)
+        {
+            PfoList allParticles;
+            // ATTN - pPrimary gets added to the list of downstream PFOs, not just the child PFOs
+            LArPfoHelper::GetAllDownstreamPfos(pPrimary, allParticles);
+            CaloHitList allHits;
+            for (const ParticleFlowObject *pPfo : allParticles)
+                LArPfoHelper::GetAllCaloHits(pPfo, allHits);
+            m_rootNodes.emplace_back(new Node(*this, allParticles, allHits));
+        }
+    }
+    else if (foldToPrimaries && foldToLeadingShowers)
+    {
+        for (const ParticleFlowObject *pPrimary : primaries)
+        {
+            PfoList allParticles, showerParticles;
+            int pdg{std::abs(pPrimary->GetParticleId())};
+            const bool isShower{pdg == E_MINUS};
+            // ATTN - pPrimary gets added to the list of downstream PFOs, not just the child PFOs
+            if (isShower)
+                LArPfoHelper::GetAllDownstreamPfos(pPrimary, allParticles);
+            else
+                LArPfoHelper::GetAllDownstreamPfos(pPrimary, allParticles, showerParticles);
+            CaloHitList allHits;
+            for (const ParticleFlowObject *pPfo : allParticles)
+                LArPfoHelper::GetAllCaloHits(pPfo, allHits);
+            Node *pNode{new Node(*this, allParticles, allHits)};
+            m_rootNodes.emplace_back(pNode);
+            if (!showerParticles.empty())
+            {
+                // Collect up all descendent hits for each shower and add the nodes as a child of the root node
+                for (const ParticleFlowObject *pChild : showerParticles)
+                    pNode->FillFlat(pChild);
+            }
+        }
+    }
+    else if (foldToLeadingShowers)
+    {
+        for (const ParticleFlowObject *pPrimary : primaries)
+        {
+            PfoList allParticles;
+            int pdg{std::abs(pPrimary->GetParticleId())};
+            const bool isShower{pdg == E_MINUS};
+            // ATTN - pPrimary gets added to the list of downstream PFOs, not just the child PFOs
+            if (isShower)
+                LArPfoHelper::GetAllDownstreamPfos(pPrimary, allParticles);
+            else
+                allParticles.emplace_back(pPrimary);
+
+            CaloHitList allHits;
+            for (const ParticleFlowObject *pPfo : allParticles)
+                LArPfoHelper::GetAllCaloHits(pPfo, allHits);
+            Node *pNode{new Node(*this, allParticles, allHits)};
+            m_rootNodes.emplace_back(pNode);
+            if (!isShower)
+            {
+                // Find the children of this particle and recursively add them to the hierarchy
+                const PfoList &children{pPrimary->GetDaughterPfoList()};
+                for (const ParticleFlowObject *pChild : children)
+                    pNode->FillHierarchy(pChild, foldToLeadingShowers);
+            }
+        }
+    }
+    else
+    {
+        for (const ParticleFlowObject *pPrimary : primaries)
+        {
+            PfoList allParticles{pPrimary};
+            CaloHitList allHits;
+            for (const ParticleFlowObject *pPfo : allParticles)
+                LArPfoHelper::GetAllCaloHits(pPfo, allHits);
+            Node *pNode{new Node(*this, allParticles, allHits)};
+            m_rootNodes.emplace_back(pNode);
+            // Find the children of this particle and recursively add them to the hierarchy
+            const PfoList &children{pPrimary->GetDaughterPfoList()};
+            for (const ParticleFlowObject *pChild : children)
+                pNode->FillHierarchy(pChild, foldToLeadingShowers);
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::RecoHierarchy::GetFlattenedNodes(NodeVector &nodeVector) const
+{
+    NodeList queue;
+    for (const Node *pNode : m_rootNodes)
+    {
+        nodeVector.emplace_back(pNode);
+        queue.emplace_back(pNode);
+    }
+    while (!queue.empty())
+    {
+        const NodeVector &children{queue.front()->GetChildren()};
+        queue.pop_front();
+        for (const Node *pChild : children)
+        {
+            nodeVector.emplace_back(pChild);
+            queue.emplace_back(pChild);
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const std::string LArHierarchyHelper::RecoHierarchy::ToString() const
+{
+    std::string str;
+    for (const Node *pNode : m_rootNodes)
+        str += pNode->ToString("") + "\n";
+
+    return str;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::RecoHierarchy::Node::Node(const RecoHierarchy &hierarchy, const ParticleFlowObject *pPfo) :
+    m_hierarchy(hierarchy),
+    m_pdg{0}
+{
+    if (pPfo)
+    {
+        m_pdg = pPfo->GetParticleId();
+        m_pfos.emplace_back(pPfo);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::RecoHierarchy::Node::Node(const RecoHierarchy &hierarchy, const PfoList &pfoList, const CaloHitList &caloHitList) :
+    m_hierarchy(hierarchy),
+    m_pdg{0}
+{
+    if (!pfoList.empty())
+        m_pdg = pfoList.front()->GetParticleId();
+    m_pfos = pfoList;
+    m_pfos.sort(LArPfoHelper::SortByNHits);
+    m_caloHits = caloHitList;
+    m_caloHits.sort();
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::RecoHierarchy::Node::~Node()
+{
+    m_pfos.clear();
+    m_caloHits.clear();
+    for (const Node *node : m_children)
+        delete node;
+    m_children.clear();
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::RecoHierarchy::Node::FillHierarchy(const ParticleFlowObject *pRoot, const bool foldToLeadingShowers)
+{
+    PfoList allParticles;
+    int pdg{std::abs(pRoot->GetParticleId())};
+    const bool isShower{pdg == E_MINUS};
+    if (foldToLeadingShowers && isShower)
+        LArPfoHelper::GetAllDownstreamPfos(pRoot, allParticles);
+    else
+        allParticles.emplace_back(pRoot);
+
+    CaloHitList allHits;
+    for (const ParticleFlowObject *pPfo : allParticles)
+        LArPfoHelper::GetAllCaloHits(pPfo, allHits);
+    Node *pNode{new Node(m_hierarchy, allParticles, allHits)};
+    m_children.emplace_back(pNode);
+    if (!foldToLeadingShowers || (foldToLeadingShowers && !isShower))
+    {
+        // Find the children of this particle and recursively add them to the hierarchy
+        const PfoList &children{pRoot->GetDaughterPfoList()};
+        for (const ParticleFlowObject *pChild : children)
+            pNode->FillHierarchy(pChild, foldToLeadingShowers);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::RecoHierarchy::Node::FillFlat(const ParticleFlowObject *pRoot)
+{
+    PfoList allParticles;
+    LArPfoHelper::GetAllDownstreamPfos(pRoot, allParticles);
+    CaloHitList allHits;
+    for (const ParticleFlowObject *pPfo : allParticles)
+        LArPfoHelper::GetAllCaloHits(pPfo, allHits);
+    Node *pNode{new Node(m_hierarchy, allParticles, allHits)};
+    m_children.emplace_back(pNode);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const PfoList &LArHierarchyHelper::RecoHierarchy::Node::GetRecoParticles() const
+{
+    return m_pfos;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const CaloHitList &LArHierarchyHelper::RecoHierarchy::Node::GetCaloHits() const
+{
+    return m_caloHits;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+int LArHierarchyHelper::RecoHierarchy::Node::GetParticleId() const
+{
+    return m_pdg;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const std::string LArHierarchyHelper::RecoHierarchy::Node::ToString(const std::string &prefix) const
+{
+    std::string str(prefix + "PDG: " + std::to_string(m_pdg) + " Hits: " + std::to_string(m_caloHits.size()) + "\n");
+    for (const Node *pChild : m_children)
+        str += pChild->ToString(prefix + "   ");
+
+    return str;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::MCMatches::MCMatches(const MCHierarchy::Node *pMCParticle) : m_pMCParticle{pMCParticle}
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::MCMatches::AddRecoMatch(const RecoHierarchy::Node *pReco, const int nSharedHits)
+{
+    m_recoNodes.emplace_back(pReco);
+    m_sharedHits.emplace_back(nSharedHits);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+unsigned int LArHierarchyHelper::MCMatches::GetSharedHits(const RecoHierarchy::Node *pReco) const
+{
+    auto iter{std::find(m_recoNodes.begin(), m_recoNodes.end(), pReco)};
+    if (iter == m_recoNodes.end())
+        throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+    int index = iter - m_recoNodes.begin();
+
+    return static_cast<int>(m_sharedHits[index]);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float LArHierarchyHelper::MCMatches::GetPurity(const RecoHierarchy::Node *pReco) const
+{
+    auto iter{std::find(m_recoNodes.begin(), m_recoNodes.end(), pReco)};
+    if (iter == m_recoNodes.end())
+        throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+    int index = iter - m_recoNodes.begin();
+
+    return m_sharedHits[index] / static_cast<float>(pReco->GetCaloHits().size());
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float LArHierarchyHelper::MCMatches::GetCompleteness(const RecoHierarchy::Node *pReco) const
+{
+    auto iter{std::find(m_recoNodes.begin(), m_recoNodes.end(), pReco)};
+    if (iter == m_recoNodes.end())
+        throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+    const int index{static_cast<int>(std::distance(m_recoNodes.begin(), iter))};
+
+    const unsigned int nHits{static_cast<unsigned int>(m_pMCParticle->GetCaloHits().size())};
+    return nHits ? m_sharedHits[index] / static_cast<float>(nHits) : 0.f;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::MatchInfo::QualityCuts::QualityCuts() : m_minPurity{0.5f}, m_minCompleteness{0.1f}
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::MatchInfo::QualityCuts::QualityCuts(const float minPurity, const float minCompleteness) :
+    m_minPurity{minPurity},
+    m_minCompleteness{minCompleteness}
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::MatchInfo::MatchInfo() : MatchInfo(QualityCuts())
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::MatchInfo::MatchInfo(const QualityCuts &qualityCuts) : m_qualityCuts{qualityCuts}
+{
+}
+
+void LArHierarchyHelper::MatchInfo::Match(const MCHierarchy &mcHierarchy, const RecoHierarchy &recoHierarchy)
+{
+    MCHierarchy::NodeVector mcNodes;
+    mcHierarchy.GetFlattenedNodes(mcNodes);
+    RecoHierarchy::NodeVector recoNodes;
+    recoHierarchy.GetFlattenedNodes(recoNodes);
+
+    std::sort(mcNodes.begin(), mcNodes.end(),
+        [](const MCHierarchy::Node *lhs, const MCHierarchy::Node *rhs) { return lhs->GetCaloHits().size() > rhs->GetCaloHits().size(); });
+    std::sort(recoNodes.begin(), recoNodes.end(),
+        [](const RecoHierarchy::Node *lhs, const RecoHierarchy::Node *rhs) { return lhs->GetCaloHits().size() > rhs->GetCaloHits().size(); });
+
+    std::map<const MCHierarchy::Node *, MCMatches> mcToMatchMap;
+    for (const RecoHierarchy::Node *pRecoNode : recoNodes)
+    {
+        const CaloHitList &recoHits{pRecoNode->GetCaloHits()};
+        const MCHierarchy::Node *pBestNode{nullptr};
+        size_t bestSharedHits{0};
+        for (const MCHierarchy::Node *pMCNode : mcNodes)
+        {
+            if (!pMCNode->IsReconstructable())
+                continue;
+            const CaloHitList &mcHits{pMCNode->GetCaloHits()};
+            CaloHitVector intersection;
+            std::set_intersection(mcHits.begin(), mcHits.end(), recoHits.begin(), recoHits.end(), std::back_inserter(intersection));
+
+            if (!intersection.empty())
+            {
+                const size_t sharedHits{intersection.size()};
+                if (sharedHits > bestSharedHits)
+                {
+                    bestSharedHits = sharedHits;
+                    pBestNode = pMCNode;
+                }
+            }
+        }
+        if (pBestNode)
+        {
+            auto iter{mcToMatchMap.find(pBestNode)};
+            if (iter != mcToMatchMap.end())
+            {
+                MCMatches &match(iter->second);
+                match.AddRecoMatch(pRecoNode, static_cast<int>(bestSharedHits));
+            }
+            else
+            {
+                MCMatches match(pBestNode);
+                match.AddRecoMatch(pRecoNode, static_cast<int>(bestSharedHits));
+                mcToMatchMap.insert(std::make_pair(pBestNode, match));
+            }
+        }
+        else
+        {
+            m_unmatchedReco.emplace_back(pRecoNode);
+        }
+    }
+
+    for (auto [pMCNode, matches] : mcToMatchMap)
+    {
+        (void)pMCNode; // gcc 7 requirement
+        const RecoHierarchy::NodeVector &nodeVector{matches.GetRecoMatches()};
+        if (nodeVector.size() == 1)
+        {
+            const RecoHierarchy::Node *pRecoNode{nodeVector.front()};
+            const float purity{matches.GetPurity(pRecoNode)};
+            const float completeness{matches.GetCompleteness(pRecoNode)};
+            if (purity >= m_qualityCuts.m_minPurity && completeness > m_qualityCuts.m_minCompleteness)
+                m_goodMatches.emplace_back(matches);
+            else
+                m_subThresholdMatches.emplace_back(matches);
+        }
+        else
+        {
+            m_subThresholdMatches.emplace_back(matches);
+        }
+    }
+
+    const auto predicate = [](const MCMatches &lhs, const MCMatches &rhs) {
+        return lhs.GetMC()->GetCaloHits().size() > rhs.GetMC()->GetCaloHits().size();
+    };
+    std::sort(m_goodMatches.begin(), m_goodMatches.end(), predicate);
+    std::sort(m_subThresholdMatches.begin(), m_subThresholdMatches.end(), predicate);
+
+    for (const MCHierarchy::Node *pMCNode : mcNodes)
+    {
+        if (pMCNode->IsReconstructable() && mcToMatchMap.find(pMCNode) == mcToMatchMap.end())
+            m_unmatchedMC.emplace_back(pMCNode);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::FillMCHierarchy(const MCParticleList &mcParticleList, const CaloHitList &caloHitList, const bool foldToPrimaries,
+    const bool foldToLeadingShowers, MCHierarchy &hierarchy)
+{
+    hierarchy.FillHierarchy(mcParticleList, caloHitList, foldToPrimaries, foldToLeadingShowers);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::FillRecoHierarchy(const PfoList &pfoList, const bool foldToPrimaries, const bool foldToLeadingShowers, RecoHierarchy &hierarchy)
+{
+    hierarchy.FillHierarchy(pfoList, foldToPrimaries, foldToLeadingShowers);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::MatchHierarchies(const MCHierarchy &mcHierarchy, const RecoHierarchy &recoHierarchy, MatchInfo &matchInfo)
+{
+    matchInfo.Match(mcHierarchy, recoHierarchy);
+    int nNeutrinoMCParticles{0}, nNeutrinoRecoParticles{0}, nNeutrinoRecoBTParticles{0};
+    int nCosmicMCParticles{0}, nCosmicRecoParticles{0}, nCosmicRecoBTParticles{0};
+    int nTestBeamMCParticles{0}, nTestBeamRecoParticles{0}, nTestBeamRecoBTParticles{0};
+    for (const MCMatches &match : matchInfo.GetGoodMatches())
+    {
+        const MCHierarchy::Node *pMCNode{match.GetMC()};
+        if (pMCNode->IsTestBeamParticle())
+            ++nTestBeamMCParticles;
+        else if (pMCNode->IsCosmicRay())
+            ++nCosmicMCParticles;
+        else
+            ++nNeutrinoMCParticles;
+        const int pdg{pMCNode->GetParticleId()};
+        const size_t mcHits{pMCNode->GetCaloHits().size()};
+        const std::string tag{pMCNode->IsTestBeamParticle() ? "(Beam) " : pMCNode->IsCosmicRay() ? "(Cosmic) " : ""};
+        std::cout << "MC " << tag << pdg << " hits " << mcHits << std::endl;
+        const RecoHierarchy::NodeVector &nodeVector{match.GetRecoMatches()};
+
+        for (const RecoHierarchy::Node *pRecoNode : nodeVector)
+        {
+            const unsigned int recoHits{static_cast<unsigned int>(pRecoNode->GetCaloHits().size())};
+            const unsigned int sharedHits{match.GetSharedHits(pRecoNode)};
+            const float purity{match.GetPurity(pRecoNode)};
+            const float completeness{match.GetCompleteness(pRecoNode)};
+            std::cout << "   Matched " << sharedHits << " out of " << recoHits << " with purity " << purity << " and completeness "
+                      << completeness << std::endl;
+        }
+        if (pMCNode->IsTestBeamParticle())
+            ++nTestBeamRecoParticles;
+        else if (pMCNode->IsCosmicRay())
+            ++nCosmicRecoParticles;
+        else
+            ++nNeutrinoRecoParticles;
+    }
+    for (const MCMatches &match : matchInfo.GetSubThresholdMatches())
+    {
+        const MCHierarchy::Node *pMCNode{match.GetMC()};
+        if (pMCNode->IsTestBeamParticle())
+            ++nTestBeamMCParticles;
+        else if (pMCNode->IsCosmicRay())
+            ++nCosmicMCParticles;
+        else
+            ++nNeutrinoMCParticles;
+        const int pdg{pMCNode->GetParticleId()};
+        const size_t mcHits{pMCNode->GetCaloHits().size()};
+        const std::string tag{pMCNode->IsTestBeamParticle() ? "(Beam) " : pMCNode->IsCosmicRay() ? "(Cosmic) " : ""};
+        std::cout << "MC " << tag << pdg << " hits " << mcHits << std::endl;
+        const RecoHierarchy::NodeVector &nodeVector{match.GetRecoMatches()};
+
+        for (const RecoHierarchy::Node *pRecoNode : nodeVector)
+        {
+            const unsigned int recoHits{static_cast<unsigned int>(pRecoNode->GetCaloHits().size())};
+            const unsigned int sharedHits{match.GetSharedHits(pRecoNode)};
+            const float purity{match.GetPurity(pRecoNode)};
+            const float completeness{match.GetCompleteness(pRecoNode)};
+            std::cout << "   Matched " << sharedHits << " out of " << recoHits << " with purity " << purity << " and completeness "
+                      << completeness << std::endl;
+        }
+        if (pMCNode->IsTestBeamParticle())
+            ++nTestBeamRecoBTParticles;
+        else if (pMCNode->IsCosmicRay())
+            ++nCosmicRecoBTParticles;
+        else
+            ++nNeutrinoRecoBTParticles;
+    }
+    for (const MCHierarchy::Node *pMCNode : matchInfo.GetUnmatchedMC())
+    {
+        if (pMCNode->IsTestBeamParticle())
+            ++nTestBeamMCParticles;
+        else if (pMCNode->IsCosmicRay())
+            ++nCosmicMCParticles;
+        else
+            ++nNeutrinoMCParticles;
+        const int pdg{pMCNode->GetParticleId()};
+        const size_t mcHits{pMCNode->GetCaloHits().size()};
+        const std::string tag{pMCNode->IsTestBeamParticle() ? "(Beam) " : pMCNode->IsCosmicRay() ? "(Cosmic) " : ""};
+        std::cout << "MC " << tag << pdg << " hits " << mcHits << std::endl;
+        std::cout << "   Unmatched" << std::endl;
+    }
+
+    if (mcHierarchy.IsNeutrinoHierarchy())
+    {
+        std::cout << "Neutrino Interaction Summary:" << std::endl;
+        std::cout << std::fixed << std::setprecision(1);
+        if (nNeutrinoMCParticles)
+        {
+            std::cout << "Matched final state particles: " << nNeutrinoRecoParticles << " of " << nNeutrinoMCParticles << " : "
+                      << (100 * nNeutrinoRecoParticles / static_cast<float>(nNeutrinoMCParticles)) << "%" << std::endl;
+        }
+        if (nCosmicMCParticles)
+        {
+            std::cout << "Matched cosmics: " << nCosmicRecoParticles << " of " << nCosmicMCParticles << " : "
+                      << (100 * nCosmicRecoParticles / static_cast<float>(nCosmicMCParticles)) << "%" << std::endl;
+        }
+    }
+    else if (mcHierarchy.IsTestBeamHierarchy())
+    {
+        std::cout << "Test Beam Interaction Summary:" << std::endl;
+        std::cout << std::fixed << std::setprecision(1);
+        if (nTestBeamMCParticles)
+        {
+            std::cout << "Matched test beam particles: " << nTestBeamRecoParticles << " of " << nTestBeamMCParticles << " : "
+                      << (100 * nTestBeamRecoParticles / static_cast<float>(nTestBeamMCParticles)) << "%" << std::endl;
+            std::cout << "Loosely matched test beam particles: " << (nTestBeamRecoParticles + nTestBeamRecoBTParticles) << " of " << nTestBeamMCParticles
+                      << " : " << (100 * (nTestBeamRecoParticles + nTestBeamRecoBTParticles) / static_cast<float>(nTestBeamMCParticles))
+                      << "%" << std::endl;
+        }
+        if (nCosmicMCParticles)
+        {
+            std::cout << "Matched cosmics: " << nCosmicRecoParticles << " of " << nCosmicMCParticles << " : "
+                      << (100 * nCosmicRecoParticles / static_cast<float>(nCosmicMCParticles)) << "%" << std::endl;
+            std::cout << "Loosely matched cosmics: " << (nCosmicRecoParticles + nCosmicRecoBTParticles) << " of " << nCosmicMCParticles << " : "
+                      << (100 * (nCosmicRecoParticles + nCosmicRecoBTParticles) / static_cast<float>(nCosmicMCParticles)) << "%" << std::endl;
+        }
+    }
+    if (!matchInfo.GetUnmatchedReco().empty())
+        std::cout << "Unmatched reco: " << matchInfo.GetUnmatchedReco().size() << std::endl;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+// private
+
+const MCParticle *LArHierarchyHelper::GetMCPrimaries(const MCParticleList &mcParticleList, MCParticleSet &primaries)
+{
+    const MCParticle *pRoot{nullptr};
+    for (const MCParticle *pMCParticle : mcParticleList)
+    {
+        try
+        {
+            const MCParticle *const pPrimary{LArMCParticleHelper::GetPrimaryMCParticle(pMCParticle)};
+            if (!LArMCParticleHelper::IsTriggeredBeamParticle(pPrimary))
+                primaries.insert(pPrimary);
+            else
+                primaries.insert(pPrimary);
+        }
+        catch (const StatusCodeException &)
+        {
+            if (LArMCParticleHelper::IsNeutrino(pMCParticle))
+                pRoot = pMCParticle;
+            else if (pMCParticle->GetParticleId() != 111 && pMCParticle->GetParticleId() < 1e9)
+                std::cout << "LArHierarchyHelper::MCHierarchy::FillHierarchy: MC particle with PDG code " << pMCParticle->GetParticleId()
+                          << " at address " << pMCParticle << " has no associated primary particle" << std::endl;
+        }
+    }
+
+    return pRoot;
+}
+
+const ParticleFlowObject *LArHierarchyHelper::GetRecoPrimaries(const PfoList &pfoList, PfoSet &primaries)
+{
+    const ParticleFlowObject *pRoot{nullptr};
+    PfoSet cosmicPfos;
+    for (const ParticleFlowObject *pPfo : pfoList)
+    {
+        if (LArPfoHelper::IsNeutrino(pPfo))
+        {
+            pRoot = pPfo;
+            break;
+        }
+        else
+        {
+            const ParticleFlowObject *const pParent{LArPfoHelper::GetParentPfo(pPfo)};
+            if (pParent && LArPfoHelper::IsNeutrino(pParent))
+            {
+                pRoot = pParent;
+                break;
+            }
+            else
+            {
+                // Should be in a test beam scenario
+                const int tier{LArPfoHelper::GetHierarchyTier(pPfo)};
+                if (tier == 0 && LArPfoHelper::IsTestBeam(pPfo))
+                {
+                    // Triggered beam particle
+                    primaries.insert(pPfo);
+                    continue;
+                }
+                if (tier > 1)
+                    continue;
+                if (!LArPfoHelper::IsTestBeam(pPfo))
+                {
+                    // Cosmic induced
+                    cosmicPfos.insert(pPfo);
+                }
+            }
+        }
+    }
+    if (pRoot && LArPfoHelper::IsNeutrino(pRoot))
+    {
+        const PfoList &children{pRoot->GetDaughterPfoList()};
+        for (const ParticleFlowObject *pPrimary : children)
+            primaries.insert(pPrimary);
+    }
+    else
+    {
+        for (const ParticleFlowObject *pPfo : cosmicPfos)
+            primaries.insert(pPfo);
+    }
+
+    return pRoot;
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArHelpers/LArHierarchyHelper.h
+++ b/larpandoracontent/LArHelpers/LArHierarchyHelper.h
@@ -1,0 +1,758 @@
+/**
+ *  @file   larpandoracontent/LArHelpers/LArHierarchyHelper.h
+ *
+ *  @brief  Header file for the lar hierarchy helper class.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_HIERARCHY_HELPER_H
+#define LAR_HIERARCHY_HELPER_H 1
+
+#include "Pandora/PandoraInternal.h"
+
+#include "Helpers/MCParticleHelper.h"
+
+#include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
+#include "larpandoracontent/LArHelpers/LArPfoHelper.h"
+
+namespace lar_content
+{
+
+/**
+ *  @brief  LArHierarchyHelper class
+ */
+class LArHierarchyHelper
+{
+public:
+    /**
+     *  @brief   MCHierarchy class
+     */
+    class MCHierarchy
+    {
+    public:
+        /**
+         *  @brief   ReconstructabilityCriteria class
+         */
+        class ReconstructabilityCriteria
+        {
+        public:
+            /**
+             *  @brief  Default constructor
+             */
+            ReconstructabilityCriteria();
+
+            /**
+             *  @brief  Copy constructor
+             */
+            ReconstructabilityCriteria(const ReconstructabilityCriteria &obj);
+
+            /**
+             *  @brief  Constructor
+             *
+             *  @param  minHits The total minimum number of hits for a particle to be considered reconstructable
+             *  @param  minHitsForGoodView The number of hits within a view for a particle to be considered reconstructable
+             *  @param  minGoodViews The minimum number of good views for a particle to be considered reconstructable
+             *  @param removeNeutrons Whether to remove neutrons and downstream particles from consideration
+             */
+            ReconstructabilityCriteria(const unsigned int minHits, const unsigned int minHitsForGoodView, const unsigned int minGoodViews,
+                const bool removeNeutrons);
+
+            const unsigned int m_minHits;            ///< the minimum number of primary good Hits
+            const unsigned int m_minHitsForGoodView; ///< the minimum number of Hits for a good view
+            const unsigned int m_minGoodViews;       ///< the minimum number of primary good views
+            const bool m_removeNeutrons;             ///< whether to remove neutrons and their downstream particles
+        };
+
+        class Node;
+        typedef std::vector<const Node *> NodeVector;
+        typedef std::list<const Node *> NodeList;
+
+        /**
+         *  @brief  Node class
+         */
+        class Node
+        {
+        public:
+            /**
+             *  @brief  Create a node with a primary MC particle
+             *
+             *  @param  hierarchy The parent hierarchy of this node
+             *  @param  pMCParticle The primary MC particle with which this node should be created
+             */
+            Node(const MCHierarchy &hierarchy, const pandora::MCParticle *pMCParticle);
+
+            /**
+             *  @brief  Create a node from a list of MC particles
+             *
+             *  @param  hierarchy The parent hierarchy of this node
+             *  @param  mcParticleList The MC particle list with which this node should be created
+             *  @parasm caloHitList The CaloHit list with which this node should be created
+             */
+            Node(const MCHierarchy &hierarchy, const pandora::MCParticleList &mcParticleList, const pandora::CaloHitList &caloHitList);
+
+            /**
+             *  @brief Destructor
+             */
+            virtual ~Node();
+
+            /**
+             *  @brief  Return whether or not this node should be considered reconstructable
+             *
+             *  @return true if reconstructable, false otherwise
+             */
+            bool IsReconstructable() const;
+
+            /**
+             *  @brief  Recursively fill the hierarchy based on the criteria established for this MCHierarchy
+             *
+             *  @param  pRoot The MC particle acting as the root of the current branch of the hierarchy
+             *  @param foldToLeadingShower Whether or not we're folding back to the leading shower particle
+             */
+            void FillHierarchy(const pandora::MCParticle *pRoot, const bool foldToLeadingShower);
+
+            /**
+             *  @brief  Fill this node by folding all descendent particles to this node
+             *
+             *  @param  pRoot The MC particle acting as the root of the current branch of the hierarchy
+             */
+            void FillFlat(const pandora::MCParticle *pRoot);
+
+            /**
+             *  @brief  Return the vector of children for this node
+             *
+             *  @return The vector of children
+             */
+            const NodeVector &GetChildren() const;
+
+            /**
+             *  @brief  Retrieve the MC particles associated with this node
+             *
+             *  @return The MC particles associated with this node
+             */
+            const pandora::MCParticleList &GetMCParticles() const;
+
+            /**
+             *  @brief  Retrieve the CaloHits associated with this node
+             *
+             *  @return The list of CaloHits associated with this node
+             */
+            const pandora::CaloHitList &GetCaloHits() const;
+
+            /**
+             *  @brief  Retrieve the PDG code for the leading particle in this node
+             *
+             *  @return The PDG code for the leading particle in this node
+             */
+            int GetParticleId() const;
+
+            /**
+             *  @brief  Check if this is a particle induced by a neutrino interaction
+             *
+             *  @return Whether or not this is neutrino induced
+             */
+            bool IsNeutrinoInduced() const;
+
+            /**
+             *  @brief  Check if this is a test beam particle
+             *
+             *  @return Whether or not this is a test beam particle
+             */
+            bool IsTestBeamParticle() const;
+
+            /**
+             *  @brief  Check if this is a cosmic ray particle
+             *
+             *  @return Whether or not this is a cosmic ray
+             */
+            bool IsCosmicRay() const;
+
+            /**
+             *  @brief  Produce a string representation of the hierarchy
+             *
+             *  @return The string representation of the hierarchy
+             */
+            const std::string ToString(const std::string &prefix) const;
+
+        private:
+            const MCHierarchy &m_hierarchy;            ///< The parent MC hierarchy
+            pandora::MCParticleList m_mcParticles;     ///< The list of MC particles of which this node is composed
+            pandora::CaloHitList m_caloHits;           ///< The list of calo hits of which this node is composed
+            NodeVector m_children;                     ///< The child nodes of this node
+            const pandora::MCParticle *m_mainParticle; ///< The leading MC particle for this node
+            int m_pdg;                                 ///< The PDG code of the leading MC particle for this node
+        };
+
+        /**
+         *  @brief  Default constructor
+         */
+        MCHierarchy() = default;
+
+        /**
+         *  @brief  Construct a new MCHierarchy object using specified reconstructability criteria
+         *
+         *  @param  recoCriteria The reconstructability criteria to be applied
+         */
+        MCHierarchy(const ReconstructabilityCriteria &recoCriteria);
+
+        /**
+         *  @brief Destructor
+         */
+        virtual ~MCHierarchy();
+
+        /**
+         *  @brief  Creates an MC hierarchy representation. Without folding this will be a mirror image of the standard MCParticle
+         *          relationships. However, with folding options selected the hierarchy structure will group together MC particles into
+         *          nodes based on the folding requirements.
+         *
+         *          If only folding back to primaries, the hierarchy will be relatively flat, with a top-level neutrino or test beam
+         *          particle, if appropriate, and then a set of leaf nodes, one for each primary particles also containing the MC particles
+         *          (and corresponding hits) from daughter particles.
+         *
+         *          If only folding back to leading shower particles, the hierarchy will largely mirror the standard MCParticle hierarchy,
+         *          but, when a shower particle is reached (for this purpose an electron or photon), this particle and all daughter
+         *          particles will be represented by a single leaf node.
+         *
+         *          If folding back to both primary and leading shower particles the hierarchy will again be rather flat, but in this case,
+         *          if a primary track-like particle (i.e. not an electron or photon) has a downstream shower particle then all downstream
+         *          particles above the shower-like particle will be folded into the primary node, but a new, daughter leaf node will be
+         *          created for the shower-like particle and all of its daughters, and a parent-child relationship will be formed between
+         *          the primary node and shower node.
+         *
+         *  @param  mcParticleList The list of MC particles with which to fill the hierarchy
+         *  @param  caloHitList The list of hits with which to fill the hierarchy
+         *  @param  foldToPrimaries Whether or not to fold daughter particles back to their primary particle
+         *  @param  foldToLeadingShowers Whether or not to fold daughter particles back to their leading shower particle
+         */
+        void FillHierarchy(const pandora::MCParticleList &mcParticleList, const pandora::CaloHitList &caloHitList,
+            const bool foldToPrimaries, const bool foldToLeadingShowers);
+
+        /**
+         *  @brief  Retrieve the root nodes in this hierarchy
+         *
+         *  @return The root nodes in this hierarchy
+         */
+        const NodeVector &GetRootNodes() const;
+
+        /**
+         *  @brief  Retrieve a flat vector of the ndoes in the hierarchy
+         *
+         *  @param  nodeVector The output vector for the nodes in the hierarchy in breadth first order
+         */
+        void GetFlattenedNodes(NodeVector &nodeVector) const;
+
+        /**
+         *  @brief  Produce a string representation of the hierarchy
+         *
+         *  @return The string representation of the hierarchy
+         */
+        const std::string ToString() const;
+
+        /**
+         *  @brief  Check if this is a neutrino hierarchy.
+         *
+         *  @return Whether or not this is a neutrino hierarchy.
+         */
+        bool IsNeutrinoHierarchy() const;
+
+        /**
+         *  @brief  Check if this is a test beam hierarchy.
+         *
+         *  @return Whether or not this is a test beam hierarchy.
+         */
+        bool IsTestBeamHierarchy() const;
+
+    private:
+        NodeVector m_rootNodes;                    ///< The leading nodes (e.g. primary particles, cosmic rays, ...)
+        ReconstructabilityCriteria m_recoCriteria; ///< The criteria used to determine if the node is reconstructable
+        const pandora::MCParticle *m_pNeutrino;    ///< The incident neutrino, if it exists
+        std::map<const pandora::MCParticle *, pandora::CaloHitList> m_mcToHitsMap; ///< The map between MC particles and calo hits
+    };
+
+    /**
+     *  @brief   RecoHierarchy class
+     */
+    class RecoHierarchy
+    {
+    public:
+        class Node;
+        typedef std::vector<const Node *> NodeVector;
+        typedef std::list<const Node *> NodeList;
+
+        /**
+         *  @brief  Node class
+         */
+        class Node
+        {
+        public:
+            /**
+             *  @brief  Create a node with a primary PFO
+             *
+             *  @param  hierarchy The parent hierarchy of this node
+             *  @param  pPfo The primary PFO with which this node should be created
+             */
+            Node(const RecoHierarchy &hierarchy, const pandora::ParticleFlowObject *pPfo);
+
+            /**
+             *  @brief  Create a node from a list of PFOs
+             *
+             *  @param  hierarchy The parent hierarchy of this node
+             *  @param  pfoList The PFO list with which this node should be created
+             *  @parasm caloHitList The CaloHit list with which this node should be created
+             */
+            Node(const RecoHierarchy &hierarchy, const pandora::PfoList &pfoList, const pandora::CaloHitList &caloHitList);
+
+            /**
+             *  @brief Destructor
+             */
+            virtual ~Node();
+
+            /**
+             *  @brief  Recursively fill the hierarchy based on the criteria established for this RecoHierarchy
+             *
+             *  @param  pRoot The PFO acting as the root of the current branch of the hierarchy
+             *  @param foldToLeadingShower Whether or not we're folding back to the leading shower particle
+             */
+            void FillHierarchy(const pandora::ParticleFlowObject *pRoot, const bool foldToLeadingShower);
+
+            /**
+             *  @brief  Fill this node by folding all descendent particles to this node
+             *
+             *  @param  pRoot The PFO acting as the root of the current branch of the hierarchy
+             */
+            void FillFlat(const pandora::ParticleFlowObject *pRoot);
+
+            /**
+             *  @brief  Return the vector of children for this node
+             *
+             *  @return The vector of children
+             */
+            const NodeVector &GetChildren() const;
+
+            /**
+             *  @brief  Retrieve the PFOs associated with this node
+             *
+             *  @return The PFOs associated with this node
+             */
+            const pandora::PfoList &GetRecoParticles() const;
+
+            /**
+             *  @brief  Retrieve the CaloHits associated with this node
+             *
+             *  @return The list of CaloHits associated with this node
+             */
+            const pandora::CaloHitList &GetCaloHits() const;
+
+            /**
+             *  @brief  Retrieve the PDG code for the leading particle in this node
+             *          Note, for reco objects the PDG codes represent tracks (muon PDG) and showers (electron PDG)
+             *
+             *  @return The PDG code for the leading particle in this node
+             */
+            int GetParticleId() const;
+
+            /**
+             *  @brief  Produce a string representation of the hierarchy
+             *
+             *  @return The string representation of the hierarchy
+             */
+            const std::string ToString(const std::string &prefix) const;
+
+        private:
+            const RecoHierarchy &m_hierarchy; ///< The parent reco hierarchy
+            pandora::PfoList m_pfos;          ///< The list of PFOs of which this node is composed
+            pandora::CaloHitList m_caloHits;  ///< The list of calo hits of which this node is composed
+            NodeVector m_children;            ///< The child nodes of this node
+            int m_pdg;                        ///< The particle ID (track = muon, shower = electron)
+        };
+
+        /**
+         *  @brief  Default constructor
+         */
+        RecoHierarchy();
+
+        /**
+         *  @brief Destructor
+         */
+        virtual ~RecoHierarchy();
+
+        /**
+         *  @brief  Creates a reconstructed hierarchy representation. Without folding this will be a mirror image of the standard
+         *          ParticleFlowObject (PFO) relationships. However, with folding options selected the hierarchy structure will group
+         *          together PFOs into nodes based on the folding requirements.
+         *
+         *          If only folding back to primaries, the hierarchy will be relatively flat, with a top-level neutrino or test beam
+         *          particle, if appropriate, and then a set of leaf nodes, one for each primary particles also containing the PFOs (and
+         *          corresponding hits) from daughter particles.
+         *
+         *          If only folding back to leading shower particles, the hierarchy will largely mirror the standard PFO hierarchy, but,
+         *          when a shower particle is reached (based on the track/shower characterisation), this particle and all daughter particles
+         *          will be represented by a single leaf node.
+         *
+         *          If folding back to both primary and leading shower particles the hierarchy will again be rather flat, but in this case,
+         *          if a primary track-like particle has a downstream shower particle then all downstream particles above the shower-like
+         *          particle will be folded into the primary node, but a new, daughter leaf node will be created for the shower-like
+         *          particle and all of its daughters, and a parent-child relationship will be formed between the primary node and shower
+         *          node.
+         *
+         *  @param  pfoList The list of PFOs with which to fill the hierarchy
+         *  @param  foldToPrimaries Whether or not to fold daughter particles back to their primary particle
+         *  @param  foldToLeadingShowers Whether or not to fold daughter particles back to their leading shower particle
+         */
+        void FillHierarchy(const pandora::PfoList &pfoList, const bool foldToPrimaries, const bool foldToLeadingShowers);
+
+        /**
+         *  @brief  Retrieve the root nodes in this hierarchy
+         *
+         *  @return The root nodes in this hierarchy
+         */
+        const NodeVector &GetRootNodes() const;
+
+        /**
+         *  @brief  Retrieve a flat vector of the nodes in the hierarchy
+         *
+         *  @param  nodeVector The output vector for the nodes in the hierarchy in breadth first order
+         */
+        void GetFlattenedNodes(NodeVector &nodeVector) const;
+
+        /**
+         *  @brief  Produce a string representation of the hierarchy
+         *
+         *  @return The string representation of the hierarchy
+         */
+        const std::string ToString() const;
+
+    private:
+        NodeVector m_rootNodes;                         ///< The leading nodes (e.g. primary particles, cosmic rays, ...)
+        const pandora::ParticleFlowObject *m_pNeutrino; ///< The incident neutrino, if it exists
+    };
+
+    /**
+     *  @brief  MCMatches class
+     */
+    class MCMatches
+    {
+    public:
+        /**
+         *  @brief  Constructor
+         *
+         *  @param  pMCParticle The MCParticle being matched
+         */
+        MCMatches(const MCHierarchy::Node *pMCParticle);
+
+        /**
+         *  @brief  Add a reconstructed node as a match for this MC node
+         *
+         *  @param  pReco The reconstructed node that matches this MC node
+         *  @param  nSharedHits The number of hits shared betweeb reco and MC nodes
+         */
+        void AddRecoMatch(const RecoHierarchy::Node *pReco, const int nSharedHits);
+
+        /**
+         *  @brief  Retrieve the MC node
+         *
+         *  @return The MC node
+         */
+        const MCHierarchy::Node *GetMC() const;
+
+        /**
+         *  @brief  Retrieve the vector of matched reco nodes
+         *
+         *  @return The vector of matched reco nodes
+         */
+        const RecoHierarchy::NodeVector &GetRecoMatches() const;
+
+        /**
+         *  @brief  Retrieve the number of shared hits in the match
+         *
+         *  @param  pReco The reco node to consider
+         *
+         *  @return The number of shared hits
+         */
+        unsigned int GetSharedHits(const RecoHierarchy::Node *pReco) const;
+
+        /**
+         *  @brief  Retrieve the purity of the match
+         *
+         *  @param  pReco The reco node to consider
+         *
+         *  @return The purity of the match
+         */
+        float GetPurity(const RecoHierarchy::Node *pReco) const;
+
+        /**
+         *  @brief  Retrieve the completeness of the match
+         *
+         *  @param  pReco The reco node to consider
+         *
+         *  @return The completeness of the match
+         */
+        float GetCompleteness(const RecoHierarchy::Node *pReco) const;
+
+    private:
+        const MCHierarchy::Node *m_pMCParticle; ///< MC node associated with any matches
+        RecoHierarchy::NodeVector m_recoNodes;  ///< Matched reco nodes
+        pandora::IntVector m_sharedHits;        ///< Number of shared hits for each match
+    };
+
+    typedef std::vector<MCMatches> MCMatchesVector;
+
+    /**
+     *  @brief  MatcheInfo class
+     */
+    class MatchInfo
+    {
+    public:
+        /**
+         *  @brief  QualityCuts class
+         */
+        class QualityCuts
+        {
+        public:
+            /**
+             *  @brief Default constructor
+             */
+            QualityCuts();
+
+            /**
+             *  @brief Constructor
+             *
+             *  @param  minPurity The minimum purity for a cut to be considered good
+             *  @param  minCompleteness The minimum completeness for a cut to be considered good
+             */
+            QualityCuts(const float minPurity, const float minCompleteness);
+
+            const float m_minPurity;       ///< The minimum purity for a match to be considered good
+            const float m_minCompleteness; ///< The minimum completeness for a match to be considered good
+        };
+
+        /**
+         *  @brief  Default constructor
+         */
+        MatchInfo();
+
+        /**
+         *  @brief  Constructor
+         *
+         *  @param  qualityCuts The quality cuts to be applied to matched nodes
+         */
+        MatchInfo(const QualityCuts &qualityCuts);
+
+        /**
+         *  @brief  Match the nodes in the MC and reco hierarchies.
+         *
+         *  @param  mcHierarchy The MC hierarchy
+         *  @param  recoHierarchy The reco hierarchy
+         */
+        void Match(const MCHierarchy &mcHierarchy, const RecoHierarchy &recoHierarchy);
+
+        /**
+         *  @brief  Retrieve the vector of good matches
+         *
+         *  @return The vector of good matches
+         */
+        const MCMatchesVector &GetGoodMatches() const;
+
+        /**
+         *  @brief  Retrieve the vector of matches that don't pass quality cuts
+         *
+         *  @return The vector of sub-threshold matches
+         */
+        const MCMatchesVector &GetSubThresholdMatches() const;
+
+        /**
+         *  @brief  Retrieve the vector of unmatched MC nodes
+         *
+         *  @return The vector of unmatched MC
+         */
+        const MCHierarchy::NodeVector &GetUnmatchedMC() const;
+
+        /**
+         *  @brief  Retrieve the vector of unmatched reco nodes
+         */
+        const RecoHierarchy::NodeVector &GetUnmatchedReco() const;
+
+    private:
+        MCMatchesVector m_goodMatches;             ///< The vector of good matches
+        MCMatchesVector m_subThresholdMatches;     ///< The vector of matches MC nodes that don't pass quality cuts
+        MCHierarchy::NodeVector m_unmatchedMC;     ///< The vector of unmatched MC nodes
+        RecoHierarchy::NodeVector m_unmatchedReco; ///< The vector of unmatched reco nodes
+        QualityCuts m_qualityCuts;                 ///< The quality cuts to be applied to matches
+    };
+
+    /**
+     *  @brief  Fill an MC hierarchy based on the specified folding criteria (see MCHierarchy::FillHierarchy for details)
+     *
+     *  @param  mcParticleList The MCParticle list to use to fill this hierarchy
+     *  @param  caloHitList The list of CaloHits to use to fill this hierarchy
+     *  @param  foldToPrimaries Whether or not to fold to primary particles
+     *  @param  foldToLeadingShowers Whether or not to fold to leading shower particles
+     *  @param  hierarchy The output MC hierarchy
+     */
+    static void FillMCHierarchy(const pandora::MCParticleList &mcParticleList, const pandora::CaloHitList &caloHitList,
+        const bool foldToPrimaries, const bool foldToLeadingShowers, MCHierarchy &hierarchy);
+
+    /**
+     *  @brief  Fill a reconstructed hierarchy based on the specified folding criteria (see RecoHierarchy::FillHierarchy for details)
+     *
+     *  @param  pfoList The ParticleFlowObject list to use to fill this hierarchy
+     *  @param  foldToPrimaries Whether or not to fold to primary particles
+     *  @param  foldToLeadingShowers Whether or not to fold to leading shower particles
+     *  @param  hierarchy The output reconstructed hierarchy
+     */
+    static void FillRecoHierarchy(const pandora::PfoList &pfoList, const bool foldToPrimaries, const bool foldToLeadingShowers, RecoHierarchy &hierarchy);
+
+    /**
+     *  @brief  Finds the matches between reconstructed and MC hierarchies.
+     *
+     *  @param  mcHierarchy The MC hiearchy
+     *  @param  recoHierarchy The reconstructed hierarchy
+     *  @param  matchInfo The output match information
+     */
+    static void MatchHierarchies(const MCHierarchy &mcHierarchy, const RecoHierarchy &recoHierarchy, MatchInfo &matchInfo);
+
+private:
+    typedef std::set<const pandora::MCParticle *> MCParticleSet;
+    typedef std::set<const pandora::ParticleFlowObject *> PfoSet;
+
+    /**
+     *  @brief  Retrieves the primary MC particles from a list and returns the root (neutrino) for hierarchy, if it exists.
+     *
+     *  @param  mcParticleList The input list of MC particles
+     *  @param  primaries The output set of primary MC particles
+     *
+     *  @return The root neutrino, if it exists, or nullptr
+     */
+    static const pandora::MCParticle *GetMCPrimaries(const pandora::MCParticleList &mcParticleList, MCParticleSet &primaries);
+
+    /**
+     *  @brief  Retrieves the primary PFOs from a list and returns the root (neutrino) for hierarchy, if it exists.
+     *
+     *  @param  pfoList The input list of PFOs
+     *  @param  primaries The output set of primary PFOs
+     *
+     *  @return The root neutrino, if it exists, or nullptr
+     */
+    static const pandora::ParticleFlowObject *GetRecoPrimaries(const pandora::PfoList &pfoList, PfoSet &primaries);
+};
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const LArHierarchyHelper::MCHierarchy::NodeVector &LArHierarchyHelper::MCHierarchy::Node::GetChildren() const
+{
+    return m_children;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const pandora::MCParticleList &LArHierarchyHelper::MCHierarchy::Node::GetMCParticles() const
+{
+    return m_mcParticles;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const pandora::CaloHitList &LArHierarchyHelper::MCHierarchy::Node::GetCaloHits() const
+{
+    return m_caloHits;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline int LArHierarchyHelper::MCHierarchy::Node::GetParticleId() const
+{
+    return m_pdg;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline bool LArHierarchyHelper::MCHierarchy::Node::IsNeutrinoInduced() const
+{
+    return !(LArHierarchyHelper::MCHierarchy::Node::IsTestBeamParticle() || LArHierarchyHelper::MCHierarchy::Node::IsCosmicRay());
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const LArHierarchyHelper::MCHierarchy::NodeVector &LArHierarchyHelper::MCHierarchy::GetRootNodes() const
+{
+    return m_rootNodes;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline bool LArHierarchyHelper::MCHierarchy::IsNeutrinoHierarchy() const
+{
+    return m_pNeutrino != nullptr;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline bool LArHierarchyHelper::MCHierarchy::IsTestBeamHierarchy() const
+{
+    return m_pNeutrino == nullptr;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const LArHierarchyHelper::RecoHierarchy::NodeVector &LArHierarchyHelper::RecoHierarchy::Node::GetChildren() const
+{
+    return m_children;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const LArHierarchyHelper::RecoHierarchy::NodeVector &LArHierarchyHelper::RecoHierarchy::GetRootNodes() const
+{
+    return m_rootNodes;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const LArHierarchyHelper::MCHierarchy::Node *LArHierarchyHelper::MCMatches::GetMC() const
+{
+    return m_pMCParticle;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const LArHierarchyHelper::RecoHierarchy::NodeVector &LArHierarchyHelper::MCMatches::GetRecoMatches() const
+{
+    return m_recoNodes;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const LArHierarchyHelper::MCMatchesVector &LArHierarchyHelper::MatchInfo::GetGoodMatches() const
+{
+    return m_goodMatches;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const LArHierarchyHelper::MCMatchesVector &LArHierarchyHelper::MatchInfo::GetSubThresholdMatches() const
+{
+    return m_subThresholdMatches;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const LArHierarchyHelper::MCHierarchy::NodeVector &LArHierarchyHelper::MatchInfo::GetUnmatchedMC() const
+{
+    return m_unmatchedMC;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const LArHierarchyHelper::RecoHierarchy::NodeVector &LArHierarchyHelper::MatchInfo::GetUnmatchedReco() const
+{
+    return m_unmatchedReco;
+}
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_HIERARCHY_HELPER_H

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
@@ -248,13 +248,39 @@ const MCParticle *LArMCParticleHelper::GetParentMCParticle(const MCParticle *con
 
 void LArMCParticleHelper::GetAllDescendentMCParticles(const pandora::MCParticle *const pMCParticle, pandora::MCParticleList &descendentMCParticleList)
 {
-    const MCParticleList &daughterMCParticleList = pMCParticle->GetDaughterList();
-    for (const MCParticle *pDaughterMCParticle : daughterMCParticleList)
+    for (const MCParticle *pDaughterMCParticle : pMCParticle->GetDaughterList())
     {
         if (std::find(descendentMCParticleList.begin(), descendentMCParticleList.end(), pDaughterMCParticle) == descendentMCParticleList.end())
         {
-            descendentMCParticleList.push_back(pDaughterMCParticle);
+            descendentMCParticleList.emplace_back(pDaughterMCParticle);
             LArMCParticleHelper::GetAllDescendentMCParticles(pDaughterMCParticle, descendentMCParticleList);
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArMCParticleHelper::GetAllDescendentMCParticles(const MCParticle *const pMCParticle, MCParticleList &descendentTrackParticles,
+    MCParticleList &leadingShowerParticles, MCParticleList &leadingNeutrons)
+{
+    for (const MCParticle *pDaughterMCParticle : pMCParticle->GetDaughterList())
+    {
+        if (std::find(descendentTrackParticles.begin(), descendentTrackParticles.end(), pDaughterMCParticle) == descendentTrackParticles.end())
+        {
+            const int pdg{std::abs(pDaughterMCParticle->GetParticleId())};
+            if (pdg == E_MINUS || pdg == PHOTON)
+            {
+                leadingShowerParticles.emplace_back(pDaughterMCParticle);
+            }
+            else if (pdg == NEUTRON)
+            {
+                leadingNeutrons.emplace_back(pDaughterMCParticle);
+            }
+            else
+            {
+                descendentTrackParticles.emplace_back(pDaughterMCParticle);
+                LArMCParticleHelper::GetAllDescendentMCParticles(pDaughterMCParticle, descendentTrackParticles, leadingShowerParticles, leadingNeutrons);
+            }
         }
     }
 }

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.h
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.h
@@ -226,6 +226,19 @@ public:
     static void GetAllDescendentMCParticles(const pandora::MCParticle *const pMCParticle, pandora::MCParticleList &descendentMCParticleList);
 
     /**
+     *  @brief  Get all descendent mc particles, separated into track-like, shower-like and neutron branches.
+     *          This method collects together all track-like particles (i.e. not electron, photon or neutron) downstream of the root
+     *          particle, stopping at a leading shower or neutron and then storing that leading shower or neutron in a separate list.
+     *
+     *  @param  pMCParticle the input mc particle
+     *  @param  descendentTrackParticles the output list of descendent track-like particles
+     *  @param  leadingShowerParticles the output list of leading shower particles
+     *  @param  leadingNeutrons the output list of leading neutrons
+     */
+    static void GetAllDescendentMCParticles(const pandora::MCParticle *const pMCParticle, pandora::MCParticleList &descendentTrackParticles,
+        pandora::MCParticleList &leadingShowerParticles, pandora::MCParticleList &leadingNeutrons);
+
+    /**
      *  @brief  Get all ancestor mc particles
      *
      *  @param  pMCParticle the input mc particle

--- a/larpandoracontent/LArHelpers/LArPfoHelper.h
+++ b/larpandoracontent/LArHelpers/LArPfoHelper.h
@@ -70,6 +70,14 @@ public:
     static void GetIsolatedCaloHits(const pandora::ParticleFlowObject *const pPfo, const pandora::HitType &hitType, pandora::CaloHitList &caloHitList);
 
     /**
+     *  @brief  Get a list of all calo hits (including isolated) of all types from a given pfo
+     *
+     *  @param  pPfo the input Pfo
+     *  @param  caloHitList the output list of calo hits
+     */
+    static void GetAllCaloHits(const pandora::ParticleFlowObject *pPfo, pandora::CaloHitList &caloHitList);
+
+    /**
      *  @brief  Get a list of clusters of a particular hit type from a list of pfos
      *
      *  @param  pfoList the input list of Pfos
@@ -142,6 +150,18 @@ public:
      *  @param  outputPfoList to receive the output pfo list
      */
     static void GetAllDownstreamPfos(const pandora::ParticleFlowObject *const pPfo, pandora::PfoList &outputPfoList);
+
+    /**
+     *  @brief  Get flat lists of all downstream track pfos and also shower-like pfos.
+     *          This method collects together all track-like particles downstream of the root particle, stopping at a leading shower and
+     *          then storing that leading shower in a separate list.
+     *
+     *  @param  pPfo the input pfo
+     *  @param  outputTrackPfoList the output list of descendent track-like particles
+     *  @param  outputLeadingShowerParticles the output list of leading shower particles
+     */
+    static void GetAllDownstreamPfos(
+        const pandora::ParticleFlowObject *const pPfo, pandora::PfoList &outputTrackPfoList, pandora::PfoList &outputLeadingShowerPfoList);
 
     /**
      *  @brief  Determine the position in the hierarchy for the MCParticle

--- a/larpandoracontent/LArMonitoring/MuonLeadingEventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/MuonLeadingEventValidationAlgorithm.cc
@@ -269,11 +269,14 @@ void MuonLeadingEventValidationAlgorithm::ProcessOutput(
             continue;
 
         // Cosmic ray parameters
-        int ID_CR, nReconstructableChildCRLs(0);
-        float mcE_CR, mcPX_CR, mcPY_CR, mcPZ_CR;
-        int nMCHitsTotal_CR, nMCHitsU_CR, nMCHitsV_CR, nMCHitsW_CR;
-        float mcVertexX_CR, mcVertexY_CR, mcVertexZ_CR, mcEndX_CR, mcEndY_CR, mcEndZ_CR;
-        int nCorrectChildCRLs(0);
+        int nReconstructableChildCRLs(0), nCorrectChildCRLs(0);
+
+#ifdef MONITORING
+        int ID_CR(0);
+        float mcE_CR(0.f), mcPX_CR(0.f), mcPY_CR(0.f), mcPZ_CR(0.f);
+        int nMCHitsTotal_CR(0), nMCHitsU_CR(0), nMCHitsV_CR(0), nMCHitsW_CR(0);
+        float mcVertexX_CR(0.f), mcVertexY_CR(0.f), mcVertexZ_CR(0.f), mcEndX_CR(0.f), mcEndY_CR(0.f), mcEndZ_CR(0.f);
+#endif
 
         // Leading particle parameters
         FloatVector mcE_CRL, mcPX_CRL, mcPY_CRL, mcPZ_CRL;
@@ -337,15 +340,15 @@ void MuonLeadingEventValidationAlgorithm::ProcessOutput(
         ///////////////////////////////
         if (m_visualize && useInterpretedMatching)
         {
+#ifdef MONITORING
             std::cout << "MC COSMIC RAY HITS" << std::endl;
-            this->PrintHits(cosmicRayHitList, "MC_CR", BLUE);
+            this->PrintHits(cosmicRayHitList, true);
 
             const CartesianVector vertex(pCosmicRay->GetVertex()), endpoint(pCosmicRay->GetEndpoint());
             const float x0(cosmicRayHitList.front()->GetX0());
             const CartesianVector shiftedVertex(vertex.GetX() - x0, vertex.GetY(), vertex.GetZ());
             const CartesianVector shiftedEndpoint(endpoint.GetX() - x0, vertex.GetY(), vertex.GetZ());
 
-#ifdef MONITORING
             PandoraMonitoringApi::AddMarkerToVisualization(this->GetPandora(), &shiftedVertex, "T0 shifted vertex ", BLACK, 2);
             PandoraMonitoringApi::AddMarkerToVisualization(this->GetPandora(), &shiftedEndpoint, "T0 shifted endpoint", BLACK, 2);
             PandoraMonitoringApi::ViewEvent(this->GetPandora());
@@ -353,6 +356,7 @@ void MuonLeadingEventValidationAlgorithm::ProcessOutput(
         }
         ///////////////////////////////
 
+#ifdef MONITORING
         ID_CR = muonCount;
         mcE_CR = pCosmicRay->GetEnergy();
         mcPX_CR = pCosmicRay->GetMomentum().GetX();
@@ -368,6 +372,7 @@ void MuonLeadingEventValidationAlgorithm::ProcessOutput(
         nMCHitsU_CR = LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, cosmicRayHitList);
         nMCHitsV_CR = LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, cosmicRayHitList);
         nMCHitsW_CR = LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, cosmicRayHitList);
+#endif
         nReconstructableChildCRLs = childLeadingParticles.size();
 
         stringStream << "\033[34m"
@@ -392,19 +397,19 @@ void MuonLeadingEventValidationAlgorithm::ProcessOutput(
             ///////////////////////////////
             if (m_visualize && useInterpretedMatching)
             {
+#ifdef MONITORING
                 size_t mcIndex((size_t)(intptr_t *)pLeadingParticle->GetUid());
 
                 std::cout << "mcID: " << mcIndex << std::endl;
                 std::cout << "MC DELTA RAY HITS" << std::endl;
 
-                this->PrintHits(leadingParticleHitList, "MC_DR", RED);
+                this->PrintHits(leadingParticleHitList, false);
 
                 const CartesianVector vertex(pLeadingParticle->GetVertex()), endpoint(pLeadingParticle->GetEndpoint());
                 const float x0(leadingParticleHitList.front()->GetX0());
                 const CartesianVector shiftedVertex(vertex.GetX() - x0, vertex.GetY(), vertex.GetZ());
                 const CartesianVector shiftedEndpoint(endpoint.GetX() - x0, vertex.GetY(), vertex.GetZ());
 
-#ifdef MONITORING
                 PandoraMonitoringApi::AddMarkerToVisualization(this->GetPandora(), &shiftedVertex, "T0 shifted vertex", BLACK, 2);
                 PandoraMonitoringApi::AddMarkerToVisualization(this->GetPandora(), &shiftedEndpoint, "T0 shifted endpoint", BLACK, 2);
                 PandoraMonitoringApi::ViewEvent(this->GetPandora());
@@ -566,6 +571,7 @@ void MuonLeadingEventValidationAlgorithm::ProcessOutput(
                 ///////////////////////////////
                 if (m_visualize && useInterpretedMatching)
                 {
+#ifdef MONITORING
                     std::cout << stringStream.str() << std::endl;
                     std::cout << "DELTA RAY PFO HITS" << std::endl;
 
@@ -593,25 +599,15 @@ void MuonLeadingEventValidationAlgorithm::ProcessOutput(
                     }
                     else
                     {
-                        PfoList deltaRayList({pMatchedPfo});
-
-#ifdef MONITORING
-                        PandoraMonitoringApi::VisualizeParticleFlowObjects(this->GetPandora(), &deltaRayList, "Delta Ray Pfo", BLACK, false, false);
-#endif
-
-                        PfoList cosmicList({pParentPfo});
-
-#ifdef MONITORING
-                        PandoraMonitoringApi::VisualizeParticleFlowObjects(this->GetPandora(), &cosmicList, "Delta Ray Pfo", RED, false, false);
-#endif
-
+                        const PfoList deltaRayList({pMatchedPfo}), cosmicList({pParentPfo});
                         const CartesianVector &vertex(deltaRayVertexList.front()->GetPosition());
 
-#ifdef MONITORING
+                        PandoraMonitoringApi::VisualizeParticleFlowObjects(this->GetPandora(), &deltaRayList, "Delta Ray Pfo", BLACK, false, false);
+                        PandoraMonitoringApi::VisualizeParticleFlowObjects(this->GetPandora(), &cosmicList, "Delta Ray Pfo", RED, false, false);
                         PandoraMonitoringApi::AddMarkerToVisualization(this->GetPandora(), &vertex, "vertex", RED, 2);
                         PandoraMonitoringApi::ViewEvent(this->GetPandora());
-#endif
                     }
+#endif
                 }
                 ///////////////////////////////
             }
@@ -788,31 +784,31 @@ void MuonLeadingEventValidationAlgorithm::ProcessOutput(
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void MuonLeadingEventValidationAlgorithm::PrintHits(const CaloHitList caloHitList, const std::string &stringTag, const Color &colour) const
+#ifdef MONITORING
+void MuonLeadingEventValidationAlgorithm::PrintHits(const CaloHitList caloHitList, const bool isCR) const
 {
+    const std::string stringTag(isCR ? "MC_CR" : "MC_DR");
+
     for (const CaloHit *const pCaloHit : caloHitList)
     {
         const CartesianVector hitPosition(pCaloHit->GetPositionVector().GetX() - pCaloHit->GetX0(), pCaloHit->GetPositionVector().GetY(),
             pCaloHit->GetPositionVector().GetZ());
 
-#ifdef MONITORING
-        PandoraMonitoringApi::AddMarkerToVisualization(this->GetPandora(), &hitPosition, stringTag, colour, 2);
-#endif
+        PandoraMonitoringApi::AddMarkerToVisualization(this->GetPandora(), &hitPosition, stringTag, isCR ? BLUE : RED, 2);
     }
 
-#ifdef MONITORING
     PandoraMonitoringApi::ViewEvent(this->GetPandora());
-#endif
 }
+#endif
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+#ifdef MONITORING
 void MuonLeadingEventValidationAlgorithm::PrintHits(const CaloHitList totalCaloHitList, const CaloHitList otherShowerCaloHitList,
     const CaloHitList otherTrackCaloHitList, const CaloHitList parentTrackCaloHitList, const std::string &stringTag) const
 {
     for (const CaloHit *const pCaloHit : totalCaloHitList)
     {
-        Color color(BLACK);
         std::string newStringTag(stringTag);
         const CartesianVector hitPosition(pCaloHit->GetPositionVector().GetX() - pCaloHit->GetX0(), pCaloHit->GetPositionVector().GetY(),
             pCaloHit->GetPositionVector().GetZ());
@@ -820,39 +816,39 @@ void MuonLeadingEventValidationAlgorithm::PrintHits(const CaloHitList totalCaloH
         if (std::find(otherShowerCaloHitList.begin(), otherShowerCaloHitList.end(), pCaloHit) != otherShowerCaloHitList.end())
         {
             newStringTag += "_OTHER_SHOWER";
-            color = VIOLET;
-        }
 
-        if (std::find(otherTrackCaloHitList.begin(), otherTrackCaloHitList.end(), pCaloHit) != otherTrackCaloHitList.end())
+            PandoraMonitoringApi::AddMarkerToVisualization(this->GetPandora(), &hitPosition, newStringTag, VIOLET, 2);
+        }
+        else if (std::find(otherTrackCaloHitList.begin(), otherTrackCaloHitList.end(), pCaloHit) != otherTrackCaloHitList.end())
         {
             newStringTag += "_OTHER_TRACK";
-            color = RED;
-        }
 
-        if (std::find(parentTrackCaloHitList.begin(), parentTrackCaloHitList.end(), pCaloHit) != parentTrackCaloHitList.end())
+            PandoraMonitoringApi::AddMarkerToVisualization(this->GetPandora(), &hitPosition, newStringTag, RED, 2);
+        }
+        else if (std::find(parentTrackCaloHitList.begin(), parentTrackCaloHitList.end(), pCaloHit) != parentTrackCaloHitList.end())
         {
             newStringTag += "_PARENT_TRACK";
-            color = BLUE;
-        }
 
-#ifdef MONITORING
-        PandoraMonitoringApi::AddMarkerToVisualization(this->GetPandora(), &hitPosition, newStringTag, color, 2);
-#endif
+            PandoraMonitoringApi::AddMarkerToVisualization(this->GetPandora(), &hitPosition, newStringTag, BLUE, 2);
+        }
+        else
+        {
+            PandoraMonitoringApi::AddMarkerToVisualization(this->GetPandora(), &hitPosition, newStringTag, BLACK, 2);
+        }
     }
 
-#ifdef MONITORING
     PandoraMonitoringApi::ViewEvent(this->GetPandora());
-#endif
 }
+#endif
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+#ifdef MONITORING
 void MuonLeadingEventValidationAlgorithm::PrintHits(
     const CaloHitList totalCaloHitList, const CaloHitList leadingCaloHitList, const std::string &stringTag) const
 {
     for (const CaloHit *const pCaloHit : totalCaloHitList)
     {
-        Color color(DARKGREEN);
         std::string newStringTag(stringTag);
         const CartesianVector hitPosition(pCaloHit->GetPositionVector().GetX() - pCaloHit->GetX0(), pCaloHit->GetPositionVector().GetY(),
             pCaloHit->GetPositionVector().GetZ());
@@ -860,18 +856,18 @@ void MuonLeadingEventValidationAlgorithm::PrintHits(
         if (std::find(leadingCaloHitList.begin(), leadingCaloHitList.end(), pCaloHit) != leadingCaloHitList.end())
         {
             newStringTag += "_LEADING";
-            color = RED;
-        }
 
-#ifdef MONITORING
-        PandoraMonitoringApi::AddMarkerToVisualization(this->GetPandora(), &hitPosition, newStringTag, color, 2);
-#endif
+            PandoraMonitoringApi::AddMarkerToVisualization(this->GetPandora(), &hitPosition, newStringTag, RED, 2);
+        }
+        else
+        {
+            PandoraMonitoringApi::AddMarkerToVisualization(this->GetPandora(), &hitPosition, newStringTag, DARKGREEN, 2);
+        }
     }
 
-#ifdef MONITORING
     PandoraMonitoringApi::ViewEvent(this->GetPandora());
-#endif
 }
+#endif
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/larpandoracontent/LArMonitoring/MuonLeadingEventValidationAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/MuonLeadingEventValidationAlgorithm.h
@@ -111,10 +111,11 @@ private:
      *  @brief  Print leading MCParticle hits
      *
      *  @param  caloHitList the list of hits to print
-     *  @param  stringTag the event display marker string
-     *  @param  colour the colour of the event display markers
+     *  @param  isCR whether the hits belong to a MC cosmic ray or delta ray/michel electron
      */
-    void PrintHits(const pandora::CaloHitList caloHitList, const std::string &stringTag, const Color &colour) const;
+#ifdef MONITORING
+    void PrintHits(const pandora::CaloHitList caloHitList, const bool isCR) const;
+#endif
 
     /**
      *  @brief  Print leading pfo hits
@@ -125,8 +126,10 @@ private:
      *  @param  parentTrackCaloHitList the list of hits that in truth belong to the parent cosmic ray
      *  @param  stringTag the event display marker string
      */
+#ifdef MONITORING
     void PrintHits(const pandora::CaloHitList totalCaloHitList, const pandora::CaloHitList otherShowerCaloHitList,
         const pandora::CaloHitList otherTrackCaloHitList, const pandora::CaloHitList parentTrackCaloHitList, const std::string &stringTag) const;
+#endif
 
     /**
      *  @brief  Print hits of the parent cosmic ray

--- a/larpandoracontent/LArUtility/PfoHitCleaningAlgorithm.cc
+++ b/larpandoracontent/LArUtility/PfoHitCleaningAlgorithm.cc
@@ -1,0 +1,68 @@
+/**
+ *  @file   larpandoracontent/LArUtility/PfoHitCleaningAlgorithm.cc
+ *
+ *  @brief  Implementation of the pfo hit cleaning algorithm class.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArPfoHelper.h"
+#include "larpandoracontent/LArUtility/PfoHitCleaningAlgorithm.h"
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+StatusCode PfoHitCleaningAlgorithm::Run()
+{
+    for (unsigned int i = 0; i < m_pfoListNames.size(); ++i)
+    {
+        // ATTN - one-to-one correspondance required between PFO and cluster lists
+        const std::string &pfoListName{m_pfoListNames.at(i)};
+        const std::string &clusterListName{m_clusterListNames.at(i)};
+        const PfoList *pList(nullptr);
+        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, pfoListName, pList));
+
+        if (pList && !pList->empty())
+        {
+            for (const ParticleFlowObject *pPfo : *pList)
+            {
+                ClusterList clustersToRemove;
+                LArPfoHelper::GetClusters(pPfo, TPC_3D, clustersToRemove);
+
+                for (const Cluster *pCluster : clustersToRemove)
+                {
+                    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::RemoveFromPfo(*this, pPfo, pCluster));
+                    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+                        PandoraContentApi::Delete<Cluster>(*this, pCluster, clusterListName));
+                }
+            }
+        }
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode PfoHitCleaningAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "PfoListNames", m_pfoListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "ClusterListNames", m_clusterListNames));
+
+    if (m_pfoListNames.size() != m_clusterListNames.size())
+    {
+        std::cout << "PfoHitCleaningAlgorithm: Mismatch between PFO and Cluster list sizes" << std::endl;
+        return STATUS_CODE_INVALID_PARAMETER;
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArUtility/PfoHitCleaningAlgorithm.h
+++ b/larpandoracontent/LArUtility/PfoHitCleaningAlgorithm.h
@@ -1,0 +1,31 @@
+/**
+ *  @file   larpandoracontent/LArUtility/PfoHitCleaningAlgorithm.h
+ *
+ *  @brief  Header file for the pfo hit cleaning algorithm class.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_PFO_HIT_CLEANING_ALGORITHM_H
+#define LAR_PFO_HIT_CLEANING_ALGORITHM_H 1
+
+#include "Pandora/Algorithm.h"
+
+namespace lar_content
+{
+
+/**
+ *  @brief  PfoHitCleaningAlgorithm class
+ */
+class PfoHitCleaningAlgorithm : public pandora::Algorithm
+{
+private:
+    pandora::StatusCode Run();
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    pandora::StringVector m_pfoListNames;     ///< The list of pfo list names
+    pandora::StringVector m_clusterListNames; ///< The list of cluster list names
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_PFO_HIT_CLEANING_ALGORITHM_H


### PR DESCRIPTION
This PR includes updates to

- Clean up 3D hits in order to support iterative shower growing: [#175](https://github.com/PandoraPFA/LArContent/pull/175)
- Provide helper tools to perform matching between reconstructed and MC particle hierarchies: [#170](https://github.com/PandoraPFA/LArContent/pull/170)
- Fix an issue when building larpandoracontent without PandoraMonitoring: [#176](https://github.com/PandoraPFA/LArContent/pull/176)

No product changes are expected for any experiment.