### PR TITLE
Update to clang-format following move to Clang 15

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,9 +4,10 @@ AccessModifierOffset: -4
 AlignAfterOpenBracket: DontAlign
 AlignConsecutiveAssignments: false
 AlignEscapedNewlines: Right
-AlignOperands: true
+AlignOperands: DontAlign
 AlignTrailingComments: true
 AllowShortFunctionsOnASingleLine: false
+AllowShortLambdasOnASingleLine: All
 AlwaysBreakTemplateDeclarations: true
 BinPackArguments: true
 BinPackParameters: true
@@ -14,13 +15,13 @@ BreakBeforeBraces: Allman
 BreakConstructorInitializers: AfterColon
 BreakStringLiterals: false
 ColumnLimit: 140
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 IncludeBlocks: Preserve
 IndentCaseLabels: true
 IndentWidth: 4
 MaxEmptyLinesToKeep: 1
+PackConstructorInitializers: Never
 PenaltyBreakAssignment: 0
 PenaltyBreakBeforeFirstCallParameter: 100
 PenaltyBreakComment: 0

--- a/larpandoracontent/LArCheating/CheatingBeamParticleIdTool.cc
+++ b/larpandoracontent/LArCheating/CheatingBeamParticleIdTool.cc
@@ -18,7 +18,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-CheatingBeamParticleIdTool::CheatingBeamParticleIdTool() : m_minWeightFraction(0.5f)
+CheatingBeamParticleIdTool::CheatingBeamParticleIdTool() :
+    m_minWeightFraction(0.5f)
 {
 }
 

--- a/larpandoracontent/LArCheating/CheatingClusterCreationAlgorithm.cc
+++ b/larpandoracontent/LArCheating/CheatingClusterCreationAlgorithm.cc
@@ -15,7 +15,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-CheatingClusterCreationAlgorithm::CheatingClusterCreationAlgorithm() : m_collapseToPrimaryMCParticles(false)
+CheatingClusterCreationAlgorithm::CheatingClusterCreationAlgorithm() :
+    m_collapseToPrimaryMCParticles(false)
 {
 }
 

--- a/larpandoracontent/LArCheating/CheatingCosmicRayIdentificationAlg.cc
+++ b/larpandoracontent/LArCheating/CheatingCosmicRayIdentificationAlg.cc
@@ -19,7 +19,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-CheatingCosmicRayIdentificationAlg::CheatingCosmicRayIdentificationAlg() : m_maxNeutrinoFraction(0.5f)
+CheatingCosmicRayIdentificationAlg::CheatingCosmicRayIdentificationAlg() :
+    m_maxNeutrinoFraction(0.5f)
 {
 }
 

--- a/larpandoracontent/LArCheating/CheatingCosmicRayTaggingTool.cc
+++ b/larpandoracontent/LArCheating/CheatingCosmicRayTaggingTool.cc
@@ -19,7 +19,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-CheatingCosmicRayTaggingTool::CheatingCosmicRayTaggingTool() : m_maxCosmicRayFraction(0.25f)
+CheatingCosmicRayTaggingTool::CheatingCosmicRayTaggingTool() :
+    m_maxCosmicRayFraction(0.25f)
 {
 }
 

--- a/larpandoracontent/LArCheating/CheatingEventSlicingTool.cc
+++ b/larpandoracontent/LArCheating/CheatingEventSlicingTool.cc
@@ -101,9 +101,9 @@ void CheatingEventSlicingTool::FillSlices(const Algorithm *const pAlgorithm, con
                 throw StatusCodeException(STATUS_CODE_FAILURE);
 
             Slice &slice(mapIter->second);
-            CaloHitList &caloHitList((TPC_VIEW_U == hitType)   ? slice.m_caloHitListU
-                                     : (TPC_VIEW_V == hitType) ? slice.m_caloHitListV
-                                                               : slice.m_caloHitListW);
+            CaloHitList &caloHitList((TPC_VIEW_U == hitType) ? slice.m_caloHitListU
+                    : (TPC_VIEW_V == hitType)                ? slice.m_caloHitListV
+                                                             : slice.m_caloHitListW);
             caloHitList.push_back(pCaloHit);
         }
         catch (const StatusCodeException &statusCodeException)

--- a/larpandoracontent/LArCheating/CheatingNeutrinoCreationAlgorithm.cc
+++ b/larpandoracontent/LArCheating/CheatingNeutrinoCreationAlgorithm.cc
@@ -18,7 +18,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-CheatingNeutrinoCreationAlgorithm::CheatingNeutrinoCreationAlgorithm() : m_collapseToPrimaryMCParticles(false), m_vertexTolerance(0.5f)
+CheatingNeutrinoCreationAlgorithm::CheatingNeutrinoCreationAlgorithm() :
+    m_collapseToPrimaryMCParticles(false),
+    m_vertexTolerance(0.5f)
 {
 }
 

--- a/larpandoracontent/LArCheating/CheatingNeutrinoDaughterVerticesAlgorithm.cc
+++ b/larpandoracontent/LArCheating/CheatingNeutrinoDaughterVerticesAlgorithm.cc
@@ -17,7 +17,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-CheatingNeutrinoDaughterVerticesAlgorithm::CheatingNeutrinoDaughterVerticesAlgorithm() : m_collapseToPrimaryMCParticles(false)
+CheatingNeutrinoDaughterVerticesAlgorithm::CheatingNeutrinoDaughterVerticesAlgorithm() :
+    m_collapseToPrimaryMCParticles(false)
 {
 }
 

--- a/larpandoracontent/LArCheating/CheatingSliceSelectionTool.cc
+++ b/larpandoracontent/LArCheating/CheatingSliceSelectionTool.cc
@@ -17,7 +17,10 @@ using namespace pandora;
 namespace lar_content
 {
 
-CheatingSliceSelectionTool::CheatingSliceSelectionTool() : m_maxSlices{1}, m_threshold{-1.f}, m_cutVariable{"completeness"}
+CheatingSliceSelectionTool::CheatingSliceSelectionTool() :
+    m_maxSlices{1},
+    m_threshold{-1.f},
+    m_cutVariable{"completeness"}
 {
 }
 

--- a/larpandoracontent/LArCheating/CheatingVertexCreationAlgorithm.cc
+++ b/larpandoracontent/LArCheating/CheatingVertexCreationAlgorithm.cc
@@ -18,7 +18,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-CheatingVertexCreationAlgorithm::CheatingVertexCreationAlgorithm() : m_replaceCurrentVertexList(true), m_vertexXCorrection(0.f)
+CheatingVertexCreationAlgorithm::CheatingVertexCreationAlgorithm() :
+    m_replaceCurrentVertexList(true),
+    m_vertexXCorrection(0.f)
 {
 }
 

--- a/larpandoracontent/LArControlFlow/BdtBeamParticleIdTool.cc
+++ b/larpandoracontent/LArControlFlow/BdtBeamParticleIdTool.cc
@@ -351,7 +351,9 @@ void BdtBeamParticleIdTool::SelectPfosByAdaBDTScore(const pandora::Algorithm *co
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 BdtBeamParticleIdTool::Plane::Plane(const CartesianVector &normal, const CartesianVector &point) :
-    m_unitNormal(0.f, 0.f, 0.f), m_point(point), m_d(-1. * static_cast<double>(normal.GetDotProduct(point)))
+    m_unitNormal(0.f, 0.f, 0.f),
+    m_point(point),
+    m_d(-1. * static_cast<double>(normal.GetDotProduct(point)))
 {
     try
     {
@@ -429,7 +431,8 @@ void BdtBeamParticleIdTool::SliceFeatureParameters::Initialize(const float larTP
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 BdtBeamParticleIdTool::SliceFeatures::SliceFeatures(const PfoList &pfosNu, const PfoList &pfosCr, const SliceFeatureParameters &sliceFeatureParameters) :
-    m_isAvailable(false), m_sliceFeatureParameters(sliceFeatureParameters)
+    m_isAvailable(false),
+    m_sliceFeatureParameters(sliceFeatureParameters)
 {
     try
     {
@@ -548,8 +551,7 @@ void BdtBeamParticleIdTool::SliceFeatures::GetLeadingCaloHits(
     closestHitToFaceDistance = std::sqrt(hitDistanceVector.front().second);
 
     const unsigned int nInputHits(inputCaloHitList.size());
-    const unsigned int nSelectedCaloHits(
-        nInputHits < m_sliceFeatureParameters.GetNSelectedHits()
+    const unsigned int nSelectedCaloHits(nInputHits < m_sliceFeatureParameters.GetNSelectedHits()
             ? nInputHits
             : static_cast<unsigned int>(std::ceil(static_cast<float>(nInputHits) * m_sliceFeatureParameters.GetSelectedFraction() / 100.f)));
 

--- a/larpandoracontent/LArControlFlow/BeamParticleIdTool.cc
+++ b/larpandoracontent/LArControlFlow/BeamParticleIdTool.cc
@@ -51,8 +51,8 @@ void BeamParticleIdTool::SelectOutputPfos(const Algorithm *const pAlgorithm, con
         for (unsigned int sliceIndex = 0, nSlices = beamSliceHypotheses.size(); sliceIndex < nSlices; ++sliceIndex)
         {
             const PfoList &sliceOutput((m_selectAllBeamParticles || (m_selectOnlyFirstSliceBeamParticles && (0 == sliceIndex)))
-                                           ? beamSliceHypotheses.at(sliceIndex)
-                                           : crSliceHypotheses.at(sliceIndex));
+                    ? beamSliceHypotheses.at(sliceIndex)
+                    : crSliceHypotheses.at(sliceIndex));
 
             const float score(m_selectAllBeamParticles || (m_selectOnlyFirstSliceBeamParticles && (0 == sliceIndex)) ? 1.f : -1.f);
 
@@ -194,9 +194,9 @@ void BeamParticleIdTool::GetSelectedCaloHits(const CaloHitList &inputCaloHitList
     closestHitToFaceDistance = std::sqrt(hitDistanceVector.front().second);
 
     const unsigned int nInputHits(inputCaloHitList.size());
-    const unsigned int nSelectedCaloHits(
-        nInputHits < m_nSelectedHits ? nInputHits
-                                     : static_cast<unsigned int>(std::round(static_cast<float>(nInputHits) * m_selectedFraction / 100.f + 0.5f)));
+    const unsigned int nSelectedCaloHits(nInputHits < m_nSelectedHits
+            ? nInputHits
+            : static_cast<unsigned int>(std::round(static_cast<float>(nInputHits) * m_selectedFraction / 100.f + 0.5f)));
 
     for (const HitDistancePair &hitDistancePair : hitDistanceVector)
     {
@@ -255,7 +255,9 @@ bool BeamParticleIdTool::IsContained(const CartesianVector &spacePoint) const
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 BeamParticleIdTool::Plane::Plane(const CartesianVector &normal, const CartesianVector &point) :
-    m_unitNormal(normal.GetUnitVector()), m_point(point), m_d(-1.f * (normal.GetDotProduct(point)))
+    m_unitNormal(normal.GetUnitVector()),
+    m_point(point),
+    m_d(-1.f * (normal.GetDotProduct(point)))
 {
 }
 

--- a/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.cc
+++ b/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.cc
@@ -442,8 +442,8 @@ void CosmicRayTaggingTool::CheckIfContained(const CRCandidateList &candidates, P
             (candidate.m_endPoint1.GetY() < candidate.m_endPoint2.GetY()) ? candidate.m_endPoint1.GetZ() : candidate.m_endPoint2.GetZ());
 
         const bool isContained((upperY < m_face_Yt - m_marginY) && (upperY > m_face_Yb + m_marginY) && (lowerY < m_face_Yt - m_marginY) &&
-                               (lowerY > m_face_Yb + m_marginY) && (zAtUpperY < m_face_Zd - m_marginZ) && (zAtUpperY > m_face_Zu + m_marginZ) &&
-                               (zAtLowerY < m_face_Zd - m_marginZ) && (zAtLowerY > m_face_Zu + m_marginZ));
+            (lowerY > m_face_Yb + m_marginY) && (zAtUpperY < m_face_Zd - m_marginZ) && (zAtUpperY > m_face_Zu + m_marginZ) &&
+            (zAtLowerY < m_face_Zd - m_marginZ) && (zAtLowerY > m_face_Zu + m_marginZ));
 
         if (!pfoToIsContainedMap.insert(PfoToBoolMap::value_type(candidate.m_pPfo, isContained)).second)
             throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
@@ -490,7 +490,7 @@ void CosmicRayTaggingTool::GetNeutrinoSlices(const CRCandidateList &candidates, 
             continue;
 
         const bool likelyNeutrino(candidate.m_canFit && sliceIdToIsInTimeMap.at(candidate.m_sliceId) &&
-                                  (candidate.m_theta < m_maxNeutrinoCosTheta || pfoToIsContainedMap.at(candidate.m_pPfo)));
+            (candidate.m_theta < m_maxNeutrinoCosTheta || pfoToIsContainedMap.at(candidate.m_pPfo)));
 
         if (likelyNeutrino)
             (void)neutrinoSliceSet.insert(candidate.m_sliceId);
@@ -504,11 +504,11 @@ void CosmicRayTaggingTool::TagCRMuons(const CRCandidateList &candidates, const P
 {
     for (const CRCandidate &candidate : candidates)
     {
-        const bool likelyCRMuon(
-            !neutrinoSliceSet.count(candidate.m_sliceId) &&
+        const bool likelyCRMuon(!neutrinoSliceSet.count(candidate.m_sliceId) &&
             (!pfoToInTimeMap.at(candidate.m_pPfo) ||
-                (candidate.m_canFit && (pfoToIsTopToBottomMap.at(candidate.m_pPfo) ||
-                                           ((candidate.m_theta > m_minCosmicCosTheta) && (candidate.m_curvature < m_maxCosmicCurvature))))));
+                (candidate.m_canFit &&
+                    (pfoToIsTopToBottomMap.at(candidate.m_pPfo) ||
+                        ((candidate.m_theta > m_minCosmicCosTheta) && (candidate.m_curvature < m_maxCosmicCurvature))))));
 
         if (!pfoToIsLikelyCRMuonMap.insert(PfoToBoolMap::value_type(candidate.m_pPfo, likelyCRMuon)).second)
             throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);

--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
@@ -943,8 +943,9 @@ const Pandora *MasterAlgorithm::CreateWorkerInstance(
     {
         const LineGap *const pLineGap(dynamic_cast<const LineGap *>(pGap));
 
-        if (pLineGap && (((pLineGap->GetLineEndX() >= tpcMinX) && (pLineGap->GetLineEndX() <= tpcMaxX)) ||
-                            ((pLineGap->GetLineStartX() >= tpcMinX) && (pLineGap->GetLineStartX() <= tpcMaxX))))
+        if (pLineGap &&
+            (((pLineGap->GetLineEndX() >= tpcMinX) && (pLineGap->GetLineEndX() <= tpcMaxX)) ||
+                ((pLineGap->GetLineStartX() >= tpcMinX) && (pLineGap->GetLineStartX() <= tpcMaxX))))
         {
             PandoraApi::Geometry::LineGap::Parameters lineGapParameters;
             const LineGapType lineGapType(pLineGap->GetLineGapType());

--- a/larpandoracontent/LArControlFlow/NeutrinoIdTool.cc
+++ b/larpandoracontent/LArControlFlow/NeutrinoIdTool.cc
@@ -329,7 +329,8 @@ void NeutrinoIdTool<T>::SelectPfos(const PfoList &pfos, PfoList &selectedPfos) c
 // TODO think about how to make this function cleaner when features are more established
 template <typename T>
 NeutrinoIdTool<T>::SliceFeatures::SliceFeatures(const PfoList &nuPfos, const PfoList &crPfos, const NeutrinoIdTool<T> *const pTool) :
-    m_isAvailable(false), m_pTool(pTool)
+    m_isAvailable(false),
+    m_pTool(pTool)
 {
     try
     {
@@ -526,7 +527,8 @@ void NeutrinoIdTool<T>::SliceFeatures::GetSpacePoints(const ParticleFlowObject *
 template <typename T>
 CartesianVector NeutrinoIdTool<T>::SliceFeatures::GetDirectionFromVertex(const CartesianPointVector &spacePoints, const CartesianVector &vertex) const
 {
-    return this->GetDirection(spacePoints, [&](const CartesianVector &pointA, const CartesianVector &pointB)
+    return this->GetDirection(spacePoints,
+        [&](const CartesianVector &pointA, const CartesianVector &pointB)
         { return ((pointA - vertex).GetMagnitude() < (pointB - vertex).GetMagnitude()); });
 }
 

--- a/larpandoracontent/LArControlFlow/PostProcessingAlgorithm.cc
+++ b/larpandoracontent/LArControlFlow/PostProcessingAlgorithm.cc
@@ -15,7 +15,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-PostProcessingAlgorithm::PostProcessingAlgorithm() : m_listCounter(0)
+PostProcessingAlgorithm::PostProcessingAlgorithm() :
+    m_listCounter(0)
 {
 }
 

--- a/larpandoracontent/LArControlFlow/SimpleNeutrinoIdTool.cc
+++ b/larpandoracontent/LArControlFlow/SimpleNeutrinoIdTool.cc
@@ -15,7 +15,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-SimpleNeutrinoIdTool::SimpleNeutrinoIdTool() : m_selectAllNeutrinos(true), m_selectOnlyFirstSliceNeutrinos(false)
+SimpleNeutrinoIdTool::SimpleNeutrinoIdTool() :
+    m_selectAllNeutrinos(true),
+    m_selectOnlyFirstSliceNeutrinos(false)
 {
 }
 
@@ -30,8 +32,8 @@ void SimpleNeutrinoIdTool::SelectOutputPfos(const Algorithm *const pAlgorithm, c
     for (unsigned int sliceIndex = 0, nSlices = nuSliceHypotheses.size(); sliceIndex < nSlices; ++sliceIndex)
     {
         const PfoList &sliceOutput((m_selectAllNeutrinos || (m_selectOnlyFirstSliceNeutrinos && (0 == sliceIndex)))
-                                       ? nuSliceHypotheses.at(sliceIndex)
-                                       : crSliceHypotheses.at(sliceIndex));
+                ? nuSliceHypotheses.at(sliceIndex)
+                : crSliceHypotheses.at(sliceIndex));
 
         const float score(m_selectAllNeutrinos || (m_selectOnlyFirstSliceNeutrinos && (0 == sliceIndex)) ? 1.f : -1.f);
 

--- a/larpandoracontent/LArControlFlow/SlicingAlgorithm.cc
+++ b/larpandoracontent/LArControlFlow/SlicingAlgorithm.cc
@@ -17,7 +17,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-SlicingAlgorithm::SlicingAlgorithm() : m_pEventSlicingTool(nullptr)
+SlicingAlgorithm::SlicingAlgorithm() :
+    m_pEventSlicingTool(nullptr)
 {
 }
 

--- a/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
+++ b/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
@@ -258,14 +258,14 @@ void StitchingCosmicRayMergingTool::CreatePfoMatches(const LArTPC &larTPC1, cons
 
     const float minL((!LArGeometryHelper::IsInGap(this->GetPandora(), pointingVertex1.GetPosition(), TPC_3D) ||
                          !LArGeometryHelper::IsInGap(this->GetPandora(), pointingVertex2.GetPosition(), TPC_3D))
-                         ? -1.f
-                         : m_relaxMinLongitudinalDisplacement);
-    const float dXdL1(m_useXcoordinate                                            ? pX1
-                      : (1.f - pX1 * pX1 > std::numeric_limits<float>::epsilon()) ? pX1 / std::sqrt(1.f - pX1 * pX1)
-                                                                                  : minL);
-    const float dXdL2(m_useXcoordinate                                            ? pX2
-                      : (1.f - pX2 * pX2 > std::numeric_limits<float>::epsilon()) ? pX2 / std::sqrt(1.f - pX2 * pX2)
-                                                                                  : minL);
+            ? -1.f
+            : m_relaxMinLongitudinalDisplacement);
+    const float dXdL1(m_useXcoordinate                                  ? pX1
+            : (1.f - pX1 * pX1 > std::numeric_limits<float>::epsilon()) ? pX1 / std::sqrt(1.f - pX1 * pX1)
+                                                                        : minL);
+    const float dXdL2(m_useXcoordinate                                  ? pX2
+            : (1.f - pX2 * pX2 > std::numeric_limits<float>::epsilon()) ? pX2 / std::sqrt(1.f - pX2 * pX2)
+                                                                        : minL);
     const float maxL1(maxLongitudinalDisplacementX / dXdL1);
     const float maxL2(maxLongitudinalDisplacementX / dXdL2);
 
@@ -789,7 +789,9 @@ bool StitchingCosmicRayMergingTool::CalculateX0(const PfoToLArTPCMap &pfoToLArTP
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StitchingCosmicRayMergingTool::PfoAssociation::PfoAssociation(const VertexType parent, const VertexType daughter, const float fom) :
-    m_parent(parent), m_daughter(daughter), m_fom(fom)
+    m_parent(parent),
+    m_daughter(daughter),
+    m_fom(fom)
 {
 }
 

--- a/larpandoracontent/LArControlFlow/StreamingAlgorithm.cc
+++ b/larpandoracontent/LArControlFlow/StreamingAlgorithm.cc
@@ -23,7 +23,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-StreamingAlgorithm::StreamingAlgorithm() : m_listType{"cluster"}
+StreamingAlgorithm::StreamingAlgorithm() :
+    m_listType{"cluster"}
 {
 }
 

--- a/larpandoracontent/LArCustomParticles/PcaShowerParticleBuildingAlgorithm.cc
+++ b/larpandoracontent/LArCustomParticles/PcaShowerParticleBuildingAlgorithm.cc
@@ -23,7 +23,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-PcaShowerParticleBuildingAlgorithm::PcaShowerParticleBuildingAlgorithm() : m_layerFitHalfWindow(20)
+PcaShowerParticleBuildingAlgorithm::PcaShowerParticleBuildingAlgorithm() :
+    m_layerFitHalfWindow(20)
 {
 }
 

--- a/larpandoracontent/LArCustomParticles/TrackParticleBuildingAlgorithm.cc
+++ b/larpandoracontent/LArCustomParticles/TrackParticleBuildingAlgorithm.cc
@@ -22,7 +22,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-TrackParticleBuildingAlgorithm::TrackParticleBuildingAlgorithm() : m_slidingFitHalfWindow(20)
+TrackParticleBuildingAlgorithm::TrackParticleBuildingAlgorithm() :
+    m_slidingFitHalfWindow(20)
 {
 }
 

--- a/larpandoracontent/LArHelpers/LArClusterHelper.cc
+++ b/larpandoracontent/LArHelpers/LArClusterHelper.cc
@@ -133,7 +133,7 @@ float LArClusterHelper::GetLayerOccupancy(const Cluster *const pCluster1, const 
 {
     const unsigned int nOccupiedLayers(pCluster1->GetOrderedCaloHitList().size() + pCluster2->GetOrderedCaloHitList().size());
     const unsigned int nLayers(1 + std::max(pCluster1->GetOuterPseudoLayer(), pCluster2->GetOuterPseudoLayer()) -
-                               std::min(pCluster1->GetInnerPseudoLayer(), pCluster2->GetInnerPseudoLayer()));
+        std::min(pCluster1->GetInnerPseudoLayer(), pCluster2->GetInnerPseudoLayer()));
 
     if (nLayers > 0)
         return (static_cast<float>(nOccupiedLayers) / static_cast<float>(nLayers));
@@ -604,14 +604,14 @@ void LArClusterHelper::GetCaloHitListInBoundingBox(const pandora::Cluster *const
         for (const CaloHit *const pCaloHit : *layerEntry.second)
         {
             const CartesianVector &hitPosition = pCaloHit->GetPositionVector();
-            if (useX && (hitPosition.GetX() < minX - std::numeric_limits<float>::epsilon() ||
-                            hitPosition.GetX() > maxX + std::numeric_limits<float>::epsilon()))
+            if (useX &&
+                (hitPosition.GetX() < minX - std::numeric_limits<float>::epsilon() || hitPosition.GetX() > maxX + std::numeric_limits<float>::epsilon()))
                 continue;
-            else if (useY && (hitPosition.GetY() < minY - std::numeric_limits<float>::epsilon() ||
-                                 hitPosition.GetY() > maxY + std::numeric_limits<float>::epsilon()))
+            else if (useY &&
+                (hitPosition.GetY() < minY - std::numeric_limits<float>::epsilon() || hitPosition.GetY() > maxY + std::numeric_limits<float>::epsilon()))
                 continue;
-            else if (useZ && (hitPosition.GetZ() < minZ - std::numeric_limits<float>::epsilon() ||
-                                 hitPosition.GetZ() > maxZ + std::numeric_limits<float>::epsilon()))
+            else if (useZ &&
+                (hitPosition.GetZ() < minZ - std::numeric_limits<float>::epsilon() || hitPosition.GetZ() > maxZ + std::numeric_limits<float>::epsilon()))
                 continue;
 
             caloHitList.push_back(pCaloHit);

--- a/larpandoracontent/LArHelpers/LArConnectionPathwayHelper.h
+++ b/larpandoracontent/LArHelpers/LArConnectionPathwayHelper.h
@@ -32,7 +32,8 @@ public:
          *
          *  @param  referencePoint the point relative to which constituent hits are ordered
          */
-        SortByDistanceToPoint(const pandora::CartesianVector referencePoint) : m_referencePoint(referencePoint)
+        SortByDistanceToPoint(const pandora::CartesianVector referencePoint) :
+            m_referencePoint(referencePoint)
         {
         }
 

--- a/larpandoracontent/LArHelpers/LArDiscreteProbabilityHelper.cc
+++ b/larpandoracontent/LArHelpers/LArDiscreteProbabilityHelper.cc
@@ -57,12 +57,12 @@ float LArDiscreteProbabilityHelper::CalculateCorrelationCoefficientPValueFromStu
 
     const float dx((upperLimit - tTestStatistic) / static_cast<float>(nIntegrationSteps));
     float integral(tDistCoeff * std::pow(1.f + tTestStatistic * tTestStatistic / dof, -0.5f * (dof + 1.f)) +
-                   tDistCoeff * std::pow(1.f + upperLimit * upperLimit / dof, -0.5f * (dof + 1.f)));
+        tDistCoeff * std::pow(1.f + upperLimit * upperLimit / dof, -0.5f * (dof + 1.f)));
     for (unsigned int iStep = 1; iStep < nIntegrationSteps; ++iStep)
     {
         integral += 2.f * tDistCoeff *
-                    std::pow(1.f + (tTestStatistic + static_cast<float>(iStep) * dx) * (tTestStatistic + static_cast<float>(iStep) * dx) / dof,
-                        -0.5f * (dof + 1.f));
+            std::pow(1.f + (tTestStatistic + static_cast<float>(iStep) * dx) * (tTestStatistic + static_cast<float>(iStep) * dx) / dof,
+                -0.5f * (dof + 1.f));
     }
 
     return integral * dx / 2.f;

--- a/larpandoracontent/LArHelpers/LArFormattingHelper.cc
+++ b/larpandoracontent/LArHelpers/LArFormattingHelper.cc
@@ -86,7 +86,8 @@ void LArFormattingHelper::PrintRule(const unsigned int width)
 //--------------------------------------------------------------------------------------------------------------------------------------
 
 LArFormattingHelper::Table::Table(const StringVector &columnTitles, const unsigned int precision) :
-    m_columnTitles(columnTitles), m_precision(precision)
+    m_columnTitles(columnTitles),
+    m_precision(precision)
 {
     m_stringstream.precision(m_precision);
 

--- a/larpandoracontent/LArHelpers/LArGeometryHelper.cc
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.cc
@@ -291,7 +291,7 @@ void LArGeometryHelper::MergeThreePositions(const Pandora &pandora, const Cartes
                      (outputU.GetZ() - positionU.GetZ()) * (outputU.GetZ() - positionU.GetZ()) +
                      (outputV.GetZ() - positionV.GetZ()) * (outputV.GetZ() - positionV.GetZ()) +
                      (outputW.GetZ() - positionW.GetZ()) * (outputW.GetZ() - positionW.GetZ())) /
-                 (sigmaUVW * sigmaUVW);
+        (sigmaUVW * sigmaUVW);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArHelpers/LArHierarchyHelper.cc
+++ b/larpandoracontent/LArHelpers/LArHierarchyHelper.cc
@@ -20,21 +20,33 @@ namespace lar_content
 using namespace pandora;
 
 LArHierarchyHelper::FoldingParameters::FoldingParameters() :
-    m_foldToLeadingShowers{false}, m_foldToTier{false}, m_foldDynamic{false}, m_cosAngleTolerance{0.9962f}, m_tier{1}
+    m_foldToLeadingShowers{false},
+    m_foldToTier{false},
+    m_foldDynamic{false},
+    m_cosAngleTolerance{0.9962f},
+    m_tier{1}
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 LArHierarchyHelper::FoldingParameters::FoldingParameters(const bool foldDynamic, const float cosAngleTolerance) :
-    m_foldToLeadingShowers{false}, m_foldToTier{false}, m_foldDynamic{foldDynamic}, m_cosAngleTolerance{cosAngleTolerance}, m_tier{1}
+    m_foldToLeadingShowers{false},
+    m_foldToTier{false},
+    m_foldDynamic{foldDynamic},
+    m_cosAngleTolerance{cosAngleTolerance},
+    m_tier{1}
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 LArHierarchyHelper::FoldingParameters::FoldingParameters(const int foldingTier) :
-    m_foldToLeadingShowers{false}, m_foldToTier{true}, m_foldDynamic{false}, m_cosAngleTolerance{0.9962f}, m_tier{foldingTier}
+    m_foldToLeadingShowers{false},
+    m_foldToTier{true},
+    m_foldDynamic{false},
+    m_cosAngleTolerance{0.9962f},
+    m_tier{foldingTier}
 {
     if (m_tier < 1)
     {
@@ -46,27 +58,33 @@ LArHierarchyHelper::FoldingParameters::FoldingParameters(const int foldingTier) 
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-LArHierarchyHelper::QualityCuts::QualityCuts() : m_minPurity{0.8f}, m_minCompleteness{0.65f}
+LArHierarchyHelper::QualityCuts::QualityCuts() :
+    m_minPurity{0.8f},
+    m_minCompleteness{0.65f}
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 LArHierarchyHelper::QualityCuts::QualityCuts(const float minPurity, const float minCompleteness) :
-    m_minPurity{minPurity}, m_minCompleteness{minCompleteness}
+    m_minPurity{minPurity},
+    m_minCompleteness{minCompleteness}
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-LArHierarchyHelper::MCHierarchy::MCHierarchy() : m_nextNodeId{1}
+LArHierarchyHelper::MCHierarchy::MCHierarchy() :
+    m_nextNodeId{1}
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-LArHierarchyHelper::MCHierarchy::MCHierarchy(const ReconstructabilityCriteria &recoCriteria) : m_recoCriteria(recoCriteria), m_nextNodeId{1}
+LArHierarchyHelper::MCHierarchy::MCHierarchy(const ReconstructabilityCriteria &recoCriteria) :
+    m_recoCriteria(recoCriteria),
+    m_nextNodeId{1}
 {
 }
 
@@ -459,7 +477,7 @@ const std::string LArHierarchyHelper::MCHierarchy::ToString() const
         const LArMCParticle *const pLArRoot{dynamic_cast<const LArMCParticle *const>(pRoot)};
         if (pLArRoot)
             str += "=== MC Interaction : PDG " + std::to_string(pLArRoot->GetParticleId()) +
-                   " Energy: " + std::to_string(pLArRoot->GetEnergy()) + " Nuance: " + std::to_string(pLArRoot->GetNuanceCode()) + "\n";
+                " Energy: " + std::to_string(pLArRoot->GetEnergy()) + " Nuance: " + std::to_string(pLArRoot->GetNuanceCode()) + "\n";
         else
             str += "=== MC Interaction : PDG " + std::to_string(pRoot->GetParticleId()) + " Energy: " + std::to_string(pRoot->GetEnergy()) + "\n";
         for (const Node *pNode : nodeVector)
@@ -526,7 +544,11 @@ bool LArHierarchyHelper::MCHierarchy::IsReconstructable(const CaloHitList &caloH
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 LArHierarchyHelper::MCHierarchy::Node::Node(MCHierarchy &hierarchy, const MCParticle *pMCParticle, const int tier) :
-    m_hierarchy(hierarchy), m_mainParticle(pMCParticle), m_tier{tier}, m_pdg{0}, m_isLeadingLepton{false}
+    m_hierarchy(hierarchy),
+    m_mainParticle(pMCParticle),
+    m_tier{tier},
+    m_pdg{0},
+    m_isLeadingLepton{false}
 {
     if (pMCParticle)
     {
@@ -539,7 +561,13 @@ LArHierarchyHelper::MCHierarchy::Node::Node(MCHierarchy &hierarchy, const MCPart
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 LArHierarchyHelper::MCHierarchy::Node::Node(MCHierarchy &hierarchy, const MCParticleList &mcParticleList, const CaloHitList &caloHitList, const int tier) :
-    m_hierarchy(hierarchy), m_mcParticles(mcParticleList), m_caloHits(caloHitList), m_mainParticle(nullptr), m_tier{tier}, m_pdg{0}, m_isLeadingLepton{false}
+    m_hierarchy(hierarchy),
+    m_mcParticles(mcParticleList),
+    m_caloHits(caloHitList),
+    m_mainParticle(nullptr),
+    m_tier{tier},
+    m_pdg{0},
+    m_isLeadingLepton{false}
 {
     if (!mcParticleList.empty())
     {
@@ -614,8 +642,8 @@ void LArHierarchyHelper::MCHierarchy::Node::FillHierarchy(const MCParticle *pRoo
         if (!allParticles.empty())
         {
             const bool hasChildren{(foldParameters.m_foldToTier && LArMCParticleHelper::GetHierarchyTier(pRoot) < foldParameters.m_tier) ||
-                                   (!foldParameters.m_foldToTier && !foldParameters.m_foldToLeadingShowers) ||
-                                   (foldParameters.m_foldToLeadingShowers && !(isShower || isNeutron))};
+                (!foldParameters.m_foldToTier && !foldParameters.m_foldToLeadingShowers) ||
+                (foldParameters.m_foldToLeadingShowers && !(isShower || isNeutron))};
             // Only add the node if it either has children, or is a leaf node with hits
             if (hasChildren || (!hasChildren && !allHits.empty()))
             {
@@ -738,7 +766,7 @@ bool LArHierarchyHelper::MCHierarchy::Node::IsCosmicRay() const
 const std::string LArHierarchyHelper::MCHierarchy::Node::ToString(const std::string &prefix) const
 {
     std::string str(prefix + "PDG: " + std::to_string(m_pdg) + " Energy: " + std::to_string(m_mainParticle ? m_mainParticle->GetEnergy() : 0) +
-                    " Hits: " + std::to_string(m_caloHits.size()) + "\n");
+        " Hits: " + std::to_string(m_caloHits.size()) + "\n");
     for (const Node *pChild : m_children)
         str += pChild->ToString(prefix + "   ");
 
@@ -749,14 +777,20 @@ const std::string LArHierarchyHelper::MCHierarchy::Node::ToString(const std::str
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 LArHierarchyHelper::MCHierarchy::ReconstructabilityCriteria::ReconstructabilityCriteria() :
-    m_minHits{30}, m_minHitsForGoodView{10}, m_minGoodViews{2}, m_removeNeutrons{true}
+    m_minHits{30},
+    m_minHitsForGoodView{10},
+    m_minGoodViews{2},
+    m_removeNeutrons{true}
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 LArHierarchyHelper::MCHierarchy::ReconstructabilityCriteria::ReconstructabilityCriteria(const ReconstructabilityCriteria &obj) :
-    m_minHits{obj.m_minHits}, m_minHitsForGoodView{obj.m_minHitsForGoodView}, m_minGoodViews{obj.m_minGoodViews}, m_removeNeutrons{obj.m_removeNeutrons}
+    m_minHits{obj.m_minHits},
+    m_minHitsForGoodView{obj.m_minHitsForGoodView},
+    m_minGoodViews{obj.m_minGoodViews},
+    m_removeNeutrons{obj.m_removeNeutrons}
 {
 }
 
@@ -764,7 +798,10 @@ LArHierarchyHelper::MCHierarchy::ReconstructabilityCriteria::ReconstructabilityC
 
 LArHierarchyHelper::MCHierarchy::ReconstructabilityCriteria::ReconstructabilityCriteria(
     const unsigned int minHits, const unsigned int minHitsForGoodView, const unsigned int minGoodViews, const bool removeNeutrons) :
-    m_minHits{minHits}, m_minHitsForGoodView{minHitsForGoodView}, m_minGoodViews{minGoodViews}, m_removeNeutrons{removeNeutrons}
+    m_minHits{minHits},
+    m_minHitsForGoodView{minHitsForGoodView},
+    m_minGoodViews{minGoodViews},
+    m_removeNeutrons{removeNeutrons}
 {
 }
 
@@ -926,7 +963,9 @@ const std::string LArHierarchyHelper::RecoHierarchy::ToString() const
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 LArHierarchyHelper::RecoHierarchy::Node::Node(const RecoHierarchy &hierarchy, const ParticleFlowObject *pPfo) :
-    m_hierarchy{hierarchy}, m_mainPfo{pPfo}, m_pdg{0}
+    m_hierarchy{hierarchy},
+    m_mainPfo{pPfo},
+    m_pdg{0}
 {
     if (pPfo)
     {
@@ -938,7 +977,9 @@ LArHierarchyHelper::RecoHierarchy::Node::Node(const RecoHierarchy &hierarchy, co
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 LArHierarchyHelper::RecoHierarchy::Node::Node(const RecoHierarchy &hierarchy, const PfoList &pfoList, const CaloHitList &caloHitList) :
-    m_hierarchy(hierarchy), m_mainPfo{nullptr}, m_pdg{0}
+    m_hierarchy(hierarchy),
+    m_mainPfo{nullptr},
+    m_pdg{0}
 {
     if (!pfoList.empty())
     {
@@ -980,8 +1021,7 @@ void LArHierarchyHelper::RecoHierarchy::Node::FillHierarchy(const ParticleFlowOb
     for (const ParticleFlowObject *pPfo : allParticles)
         LArPfoHelper::GetAllCaloHits(pPfo, allHits);
     const bool hasChildren{(foldParameters.m_foldToTier && LArPfoHelper::GetHierarchyTier(pRoot) < foldParameters.m_tier) ||
-                           (!foldParameters.m_foldToTier && !foldParameters.m_foldToLeadingShowers) ||
-                           (foldParameters.m_foldToLeadingShowers && !isShower)};
+        (!foldParameters.m_foldToTier && !foldParameters.m_foldToLeadingShowers) || (foldParameters.m_foldToLeadingShowers && !isShower)};
 
     if (hasChildren || (!hasChildren && !allHits.empty()))
     {
@@ -1045,7 +1085,8 @@ const std::string LArHierarchyHelper::RecoHierarchy::Node::ToString(const std::s
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-LArHierarchyHelper::MCMatches::MCMatches(const MCHierarchy::Node *pMCParticle) : m_pMCParticle{pMCParticle}
+LArHierarchyHelper::MCMatches::MCMatches(const MCHierarchy::Node *pMCParticle) :
+    m_pMCParticle{pMCParticle}
 {
 }
 
@@ -1240,7 +1281,9 @@ LArHierarchyHelper::MatchInfo::MatchInfo(const MCHierarchy &mcHierarchy, const R
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 LArHierarchyHelper::MatchInfo::MatchInfo(const MCHierarchy &mcHierarchy, const RecoHierarchy &recoHierarchy, const QualityCuts &qualityCuts) :
-    m_mcHierarchy{mcHierarchy}, m_recoHierarchy{recoHierarchy}, m_qualityCuts{qualityCuts}
+    m_mcHierarchy{mcHierarchy},
+    m_recoHierarchy{recoHierarchy},
+    m_qualityCuts{qualityCuts}
 {
 }
 

--- a/larpandoracontent/LArHelpers/LArHitWidthHelper.cc
+++ b/larpandoracontent/LArHelpers/LArHitWidthHelper.cc
@@ -14,7 +14,9 @@ namespace lar_content
 {
 
 LArHitWidthHelper::ConstituentHit::ConstituentHit(const CartesianVector &positionVector, const float hitWidth, const Cluster *const pParentClusterAddress) :
-    m_positionVector(positionVector), m_hitWidth(hitWidth), m_pParentClusterAddress(pParentClusterAddress)
+    m_positionVector(positionVector),
+    m_hitWidth(hitWidth),
+    m_pParentClusterAddress(pParentClusterAddress)
 {
 }
 

--- a/larpandoracontent/LArHelpers/LArHitWidthHelper.h
+++ b/larpandoracontent/LArHelpers/LArHitWidthHelper.h
@@ -60,7 +60,8 @@ public:
              *
              *  @param  referencePoint the point relative to which constituent hits are ordered
              */
-            SortByDistanceToPoint(const pandora::CartesianVector referencePoint) : m_referencePoint(referencePoint)
+            SortByDistanceToPoint(const pandora::CartesianVector referencePoint) :
+                m_referencePoint(referencePoint)
             {
             }
 

--- a/larpandoracontent/LArHelpers/LArInteractionTypeHelper.cc
+++ b/larpandoracontent/LArHelpers/LArInteractionTypeHelper.cc
@@ -712,7 +712,17 @@ std::string LArInteractionTypeHelper::ToString(const InteractionType interaction
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 LArInteractionTypeHelper::InteractionParameters::InteractionParameters() :
-    m_nNonNeutrons(0), m_nMuons(0), m_nElectrons(0), m_nPhotons(0), m_nProtons(0), m_nPiPlus(0), m_nPiMinus(0), m_nPiZero(0), m_nKaonPlus(0), m_nKaonMinus(0), m_nKaon0L(0)
+    m_nNonNeutrons(0),
+    m_nMuons(0),
+    m_nElectrons(0),
+    m_nPhotons(0),
+    m_nProtons(0),
+    m_nPiPlus(0),
+    m_nPiMinus(0),
+    m_nPiZero(0),
+    m_nKaonPlus(0),
+    m_nKaonMinus(0),
+    m_nKaon0L(0)
 {
 }
 

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
@@ -111,7 +111,7 @@ bool LArMCParticleHelper::IsCosmicRay(const MCParticle *const pMCParticle)
 {
     const int nuance(LArMCParticleHelper::GetNuanceCode(pMCParticle));
     return (LArMCParticleHelper::IsPrimary(pMCParticle) &&
-            ((nuance == 3000) || ((nuance == 0) && !LArMCParticleHelper::IsBeamNeutrinoFinalState(pMCParticle))));
+        ((nuance == 3000) || ((nuance == 0) && !LArMCParticleHelper::IsBeamNeutrinoFinalState(pMCParticle))));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArHelpers/LArMonitoringHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMonitoringHelper.cc
@@ -254,8 +254,7 @@ void LArMonitoringHelper::PrintMatchingTable(const PfoVector &orderedPfoVector, 
         if (it != mcParticleToPfoHitSharingMap.end())
             pfoToSharedHitsVector = it->second;
 
-        const LArFormattingHelper::Color mcCol(
-            LArMCParticleHelper::IsBeamNeutrinoFinalState(pMCParticle)
+        const LArFormattingHelper::Color mcCol(LArMCParticleHelper::IsBeamNeutrinoFinalState(pMCParticle)
                 ? LArFormattingHelper::LIGHT_GREEN
                 : (LArMCParticleHelper::IsBeamParticle(pMCParticle) ? LArFormattingHelper::LIGHT_BLUE : LArFormattingHelper::LIGHT_RED));
 

--- a/larpandoracontent/LArHelpers/LArMuonLeadingHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMuonLeadingHelper.cc
@@ -23,7 +23,8 @@ namespace lar_content
 using namespace pandora;
 
 LArMuonLeadingHelper::ValidationParameters::ValidationParameters() :
-    LArMCParticleHelper::PrimaryParameters(), m_maxBremsstrahlungSeparation(2.5f)
+    LArMCParticleHelper::PrimaryParameters(),
+    m_maxBremsstrahlungSeparation(2.5f)
 {
 }
 

--- a/larpandoracontent/LArHelpers/LArStitchingHelper.cc
+++ b/larpandoracontent/LArHelpers/LArStitchingHelper.cc
@@ -263,12 +263,12 @@ float LArStitchingHelper::CalculateX0(const LArTPC &firstTPC, const LArTPC &seco
         throw StatusCodeException(STATUS_CODE_NOT_FOUND);
 
     const float R1(firstDirectionYZ.GetUnitVector().GetDotProduct(firstPositionYZ - secondPositionYZ) / firstDirectionYZmag);
-    const float X1(-1.f * firstDirectionX.GetUnitVector().GetDotProduct(
-                              secondVertex.GetPosition() - (firstVertex.GetPosition() - firstVertex.GetDirection() * R1)));
+    const float X1(-1.f *
+        firstDirectionX.GetUnitVector().GetDotProduct(secondVertex.GetPosition() - (firstVertex.GetPosition() - firstVertex.GetDirection() * R1)));
 
     const float R2(secondDirectionYZ.GetUnitVector().GetDotProduct(secondPositionYZ - firstPositionYZ) / secondDirectionYZmag);
-    const float X2(-1.f * secondDirectionX.GetUnitVector().GetDotProduct(
-                              firstVertex.GetPosition() - (secondVertex.GetPosition() - secondVertex.GetDirection() * R2)));
+    const float X2(-1.f *
+        secondDirectionX.GetUnitVector().GetDotProduct(firstVertex.GetPosition() - (secondVertex.GetPosition() - secondVertex.GetDirection() * R2)));
 
     // ATTN: By convention, X0 is half the displacement in x (because both Pfos will be corrected)
     return (X1 + X2) * 0.25f;

--- a/larpandoracontent/LArHelpers/LArVertexHelper.cc
+++ b/larpandoracontent/LArHelpers/LArVertexHelper.cc
@@ -98,7 +98,7 @@ bool LArVertexHelper::IsInFiducialVolume(const Pandora &pandora, const Cartesian
         const float y{vertex.GetY()};
         const float z{vertex.GetZ()};
         return (tpcMinX + 50.f) < x && x < (tpcMaxX - 50.f) && (tpcMinY + 50.f) < y && y < (tpcMaxY - 50.f) && (tpcMinZ + 50.f) < z &&
-               z < (tpcMaxZ - 150.f);
+            z < (tpcMaxZ - 150.f);
     }
     else if (detector == "dune_nd")
     {

--- a/larpandoracontent/LArMonitoring/CosmicRayTaggingMonitoringTool.cc
+++ b/larpandoracontent/LArMonitoring/CosmicRayTaggingMonitoringTool.cc
@@ -22,7 +22,10 @@ namespace lar_content
 {
 
 CosmicRayTaggingMonitoringTool::CosmicRayTaggingMonitoringTool() :
-    m_minHitsToConsiderTagging(15), m_minPurity(0.95), m_minImpurity(0.95), m_minSignificance(0.1)
+    m_minHitsToConsiderTagging(15),
+    m_minPurity(0.95),
+    m_minImpurity(0.95),
+    m_minSignificance(0.1)
 {
 }
 

--- a/larpandoracontent/LArMonitoring/HierarchyMonitoringAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/HierarchyMonitoringAlgorithm.cc
@@ -237,7 +237,7 @@ void HierarchyMonitoringAlgorithm::VisualizeMCProcess(const LArHierarchyHelper::
             CaloHitList uHits, vHits, wHits;
             this->FillHitLists(pNode->GetCaloHits(), uHits, vHits, wHits);
             std::string suffix{std::to_string(nodeIdx) + " (" + std::to_string(tier) + ") " + std::to_string(pdg) + " " + category + " " +
-                               std::to_string(process)};
+                std::to_string(process)};
             if (process == MC_PROC_DECAY)
             {
                 const MCParticleList &parentList{pMC->GetParentList()};
@@ -380,7 +380,7 @@ void HierarchyMonitoringAlgorithm::VisualizeMatches(const LArHierarchyHelper::Ma
 
                 this->FillHitLists(pReco->GetCaloHits(), uHits, vHits, wHits);
                 const std::string suffix{"Reco - Slice " + std::to_string(recoRootToSliceMap[recoNodeToRootMap[pReco]]) + " ID " +
-                                         std::to_string(recoNodeToIdMap[pReco]) + " -> " + std::to_string(mcNodeToIdMap[pMC])};
+                    std::to_string(recoNodeToIdMap[pReco]) + " -> " + std::to_string(mcNodeToIdMap[pMC])};
                 const LArHierarchyHelper::QualityCuts &quality{matchInfo.GetQualityCuts()};
                 if (purity >= quality.m_minPurity && completeness >= quality.m_minCompleteness)
                 {
@@ -420,7 +420,7 @@ void HierarchyMonitoringAlgorithm::VisualizeMatches(const LArHierarchyHelper::Ma
                     CaloHitList uHits, vHits, wHits;
                     this->FillHitLists(pNode->GetCaloHits(), uHits, vHits, wHits);
                     const std::string suffix{"Reco - Slice " + std::to_string(recoRootToSliceMap[recoNodeToRootMap[pNode]]) + " ID " +
-                                             std::to_string(recoNodeToIdMap[pNode]) + " -> #"};
+                        std::to_string(recoNodeToIdMap[pNode]) + " -> #"};
                     this->Visualize(uHits, "U " + suffix, 14);
                     this->Visualize(vHits, "V " + suffix, 14);
                     this->Visualize(wHits, "W " + suffix, 14);

--- a/larpandoracontent/LArMonitoring/HierarchyValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/HierarchyValidationAlgorithm.cc
@@ -19,7 +19,16 @@ namespace lar_content
 {
 
 HierarchyValidationAlgorithm::HierarchyValidationAlgorithm() :
-    m_event{-1}, m_detector{"dune_fd_hd"}, m_writeTree{false}, m_foldToPrimaries{false}, m_foldDynamic{false}, m_foldToLeadingShowers{false}, m_validateEvent{false}, m_validateMC{false}, m_minPurity{0.8f}, m_minCompleteness{0.65f}
+    m_event{-1},
+    m_detector{"dune_fd_hd"},
+    m_writeTree{false},
+    m_foldToPrimaries{false},
+    m_foldDynamic{false},
+    m_foldToLeadingShowers{false},
+    m_validateEvent{false},
+    m_validateMC{false},
+    m_minPurity{0.8f},
+    m_minCompleteness{0.65f}
 {
 }
 

--- a/larpandoracontent/LArMonitoring/MCParticleMonitoringAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/MCParticleMonitoringAlgorithm.cc
@@ -23,7 +23,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-MCParticleMonitoringAlgorithm::MCParticleMonitoringAlgorithm() : m_useTrueNeutrinosOnly(false), m_minHitsForDisplay(1)
+MCParticleMonitoringAlgorithm::MCParticleMonitoringAlgorithm() :
+    m_useTrueNeutrinosOnly(false),
+    m_minHitsForDisplay(1)
 {
 }
 

--- a/larpandoracontent/LArMonitoring/MuonLeadingEventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/MuonLeadingEventValidationAlgorithm.cc
@@ -243,10 +243,10 @@ void MuonLeadingEventValidationAlgorithm::ProcessOutput(
     const LArMCParticleHelper::MCContributionMap &foldedAllMCToHitsMap(validationInfo.GetAllMCParticleToHitsMap());
     const LArMCParticleHelper::MCContributionMap &foldedTargetMCToHitsMap(validationInfo.GetTargetMCParticleToHitsMap());
     const LArMCParticleHelper::PfoContributionMap &foldedPfoToHitsMap(validationInfo.GetPfoToHitsMap());
-    const LArMCParticleHelper::MCParticleToPfoHitSharingMap &foldedMCToPfoHitSharingMap(
-        (fillTree && m_writeRawMatchesToTree) ? validationInfo.GetMCToPfoHitSharingMap()
-        : useInterpretedMatching              ? validationInfo.GetInterpretedMCToPfoHitSharingMap()
-                                              : validationInfo.GetMCToPfoHitSharingMap());
+    const LArMCParticleHelper::MCParticleToPfoHitSharingMap &foldedMCToPfoHitSharingMap((fillTree && m_writeRawMatchesToTree)
+            ? validationInfo.GetMCToPfoHitSharingMap()
+            : useInterpretedMatching ? validationInfo.GetInterpretedMCToPfoHitSharingMap()
+                                     : validationInfo.GetMCToPfoHitSharingMap());
 
     // Consider only delta rays from reconstructable CR muons
     MCParticleVector mcCRVector;

--- a/larpandoracontent/LArMonitoring/NeutrinoEventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/NeutrinoEventValidationAlgorithm.cc
@@ -21,7 +21,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-NeutrinoEventValidationAlgorithm::NeutrinoEventValidationAlgorithm() : m_useTrueNeutrinosOnly(false)
+NeutrinoEventValidationAlgorithm::NeutrinoEventValidationAlgorithm() :
+    m_useTrueNeutrinosOnly(false)
 {
 }
 
@@ -368,8 +369,8 @@ void NeutrinoEventValidationAlgorithm::ProcessOutput(
             const int interactionTypeInt(static_cast<int>(interactionType));
 #endif
             // ATTN Some redundancy introduced to contributing variables
-            const int isCorrectNu(isBeamNeutrinoFinalState && (nTargetGoodNuMatches == nTargetNuMatches) && (nTargetGoodNuMatches == nTargetPrimaries) &&
-                                  (nTargetCRMatches == 0) && (nTargetNuSplits == 0) && (nTargetNuLosses == 0));
+            const int isCorrectNu(isBeamNeutrinoFinalState && (nTargetGoodNuMatches == nTargetNuMatches) &&
+                (nTargetGoodNuMatches == nTargetPrimaries) && (nTargetCRMatches == 0) && (nTargetNuSplits == 0) && (nTargetNuLosses == 0));
             const int isCorrectCR(isCosmicRay && (nTargetNuMatches == 0) && (nTargetCRMatches == 1));
             const int isFakeNu(isCosmicRay && (nTargetNuMatches > 0));
             const int isFakeCR(!isCosmicRay && (nTargetCRMatches > 0));

--- a/larpandoracontent/LArMonitoring/PfoValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/PfoValidationAlgorithm.cc
@@ -20,7 +20,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-PfoValidationAlgorithm::PfoValidationAlgorithm() : m_nMatchesToShow(3)
+PfoValidationAlgorithm::PfoValidationAlgorithm() :
+    m_nMatchesToShow(3)
 {
 }
 

--- a/larpandoracontent/LArMonitoring/ShowerTensorVisualizationTool.cc
+++ b/larpandoracontent/LArMonitoring/ShowerTensorVisualizationTool.cc
@@ -16,7 +16,10 @@ namespace lar_content
 {
 
 ShowerTensorVisualizationTool::ShowerTensorVisualizationTool() :
-    m_minClusterConnections(1), m_ignoreUnavailableClusters(true), m_showEachIndividualElement(false), m_showContext(false)
+    m_minClusterConnections(1),
+    m_ignoreUnavailableClusters(true),
+    m_showEachIndividualElement(false),
+    m_showContext(false)
 {
 }
 

--- a/larpandoracontent/LArMonitoring/TestBeamHierarchyEventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/TestBeamHierarchyEventValidationAlgorithm.cc
@@ -308,9 +308,9 @@ void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(
 #ifdef MONITORING
                 try
                 {
-                    const Vertex *const pRecoVertex(
-                        isRecoTestBeamHierarchy ? LArPfoHelper::GetTestBeamInteractionVertex(LArPfoHelper::GetParentPfo(pfoToSharedHits.first))
-                                                : LArPfoHelper::GetVertex(pfoToSharedHits.first));
+                    const Vertex *const pRecoVertex(isRecoTestBeamHierarchy
+                            ? LArPfoHelper::GetTestBeamInteractionVertex(LArPfoHelper::GetParentPfo(pfoToSharedHits.first))
+                            : LArPfoHelper::GetVertex(pfoToSharedHits.first));
                     recoVertexX = pRecoVertex->GetPosition().GetX();
                     recoVertexY = pRecoVertex->GetPosition().GetY();
                     recoVertexZ = pRecoVertex->GetPosition().GetZ();
@@ -463,8 +463,8 @@ void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(
             // ATTN Some redundancy introduced to contributing variables
             const int isCorrectTB(isBeamParticle && (nTargetTBHierarchyMatches == 1) && (nTargetCRMatches == 0));
             const int isCorrectTBHierarchy(isLeadingBeamParticle && (nTargetGoodTBHierarchyMatches == nTargetTBHierarchyMatches) &&
-                                           (nTargetGoodTBHierarchyMatches == nTargetPrimaries) && (nTargetCRMatches == 0) &&
-                                           (nTargetTBHierarchySplits == 0) && (nTargetTBHierarchyLosses == 0));
+                (nTargetGoodTBHierarchyMatches == nTargetPrimaries) && (nTargetCRMatches == 0) && (nTargetTBHierarchySplits == 0) &&
+                (nTargetTBHierarchyLosses == 0));
             const int isCorrectCR(isCosmicRay && (nTargetTBHierarchyMatches == 0) && (nTargetCRMatches == 1));
             const int isFakeTBHierarchy(isCosmicRay && (nTargetTBHierarchyMatches > 0));
             const int isFakeCR(!isCosmicRay && (nTargetCRMatches > 0));

--- a/larpandoracontent/LArMonitoring/TransverseMatrixVisualizationTool.cc
+++ b/larpandoracontent/LArMonitoring/TransverseMatrixVisualizationTool.cc
@@ -16,7 +16,10 @@ namespace lar_content
 {
 
 TransverseMatrixVisualizationTool::TransverseMatrixVisualizationTool() :
-    m_minClusterConnections(1), m_ignoreUnavailableClusters(true), m_showEachIndividualElement(false), m_showOnlyTrueMatchIndividualElements(false)
+    m_minClusterConnections(1),
+    m_ignoreUnavailableClusters(true),
+    m_showEachIndividualElement(false),
+    m_showOnlyTrueMatchIndividualElements(false)
 {
 }
 

--- a/larpandoracontent/LArMonitoring/TransverseTensorVisualizationTool.cc
+++ b/larpandoracontent/LArMonitoring/TransverseTensorVisualizationTool.cc
@@ -16,7 +16,10 @@ namespace lar_content
 {
 
 TransverseTensorVisualizationTool::TransverseTensorVisualizationTool() :
-    m_minClusterConnections(1), m_ignoreUnavailableClusters(true), m_showEachIndividualElement(false), m_showContext(false)
+    m_minClusterConnections(1),
+    m_ignoreUnavailableClusters(true),
+    m_showEachIndividualElement(false),
+    m_showContext(false)
 {
 }
 

--- a/larpandoracontent/LArMonitoring/VertexMonitoringAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/VertexMonitoringAlgorithm.cc
@@ -22,7 +22,11 @@ namespace lar_content
 {
 
 VertexMonitoringAlgorithm::VertexMonitoringAlgorithm() :
-    m_visualise{true}, m_writeFile{false}, m_transparencyThresholdE{-1.f}, m_energyScaleThresholdE{1.f}, m_scalingFactor{1.f}
+    m_visualise{true},
+    m_writeFile{false},
+    m_transparencyThresholdE{-1.f},
+    m_energyScaleThresholdE{1.f},
+    m_scalingFactor{1.f}
 {
 }
 

--- a/larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.cc
@@ -43,9 +43,9 @@ VisualMonitoringAlgorithm::VisualMonitoringAlgorithm() :
 StatusCode VisualMonitoringAlgorithm::Run()
 {
     PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), m_showDetector,
-        (m_detectorView.find("xz") != std::string::npos)   ? DETECTOR_VIEW_XZ
-        : (m_detectorView.find("xy") != std::string::npos) ? DETECTOR_VIEW_XY
-                                                           : DETECTOR_VIEW_DEFAULT,
+        (m_detectorView.find("xz") != std::string::npos)       ? DETECTOR_VIEW_XZ
+            : (m_detectorView.find("xy") != std::string::npos) ? DETECTOR_VIEW_XY
+                                                               : DETECTOR_VIEW_DEFAULT,
         m_transparencyThresholdE, m_energyScaleThresholdE, m_scalingFactor));
 
     // Show current mc particles
@@ -281,10 +281,10 @@ void VisualMonitoringAlgorithm::VisualizeClusterList(const std::string &listName
     }
 
     PANDORA_MONITORING_API(VisualizeClusters(this->GetPandora(), &clusterList, listName.empty() ? "CurrentClusters" : listName.c_str(),
-        (m_hitColors.find("particleid") != std::string::npos) ? AUTOID
-        : (m_hitColors.find("iterate") != std::string::npos)  ? AUTOITER
-        : (m_hitColors.find("energy") != std::string::npos)   ? AUTOENERGY
-                                                              : AUTO,
+        (m_hitColors.find("particleid") != std::string::npos)    ? AUTOID
+            : (m_hitColors.find("iterate") != std::string::npos) ? AUTOITER
+            : (m_hitColors.find("energy") != std::string::npos)  ? AUTOENERGY
+                                                                 : AUTO,
         m_showAssociatedTracks));
 }
 

--- a/larpandoracontent/LArObjects/LArAdaBoostDecisionTree.cc
+++ b/larpandoracontent/LArObjects/LArAdaBoostDecisionTree.cc
@@ -15,7 +15,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-AdaBoostDecisionTree::AdaBoostDecisionTree() : m_pStrongClassifier(nullptr)
+AdaBoostDecisionTree::AdaBoostDecisionTree() :
+    m_pStrongClassifier(nullptr)
 {
 }
 
@@ -180,7 +181,14 @@ double AdaBoostDecisionTree::CalculateScore(const LArMvaHelper::MvaFeatureVector
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 AdaBoostDecisionTree::Node::Node(const TiXmlHandle *const pXmlHandle) :
-    m_nodeId(0), m_parentNodeId(0), m_leftChildNodeId(0), m_rightChildNodeId(0), m_isLeaf(false), m_threshold(0.), m_variableId(0), m_outcome(false)
+    m_nodeId(0),
+    m_parentNodeId(0),
+    m_leftChildNodeId(0),
+    m_rightChildNodeId(0),
+    m_isLeaf(false),
+    m_threshold(0.),
+    m_variableId(0),
+    m_outcome(false)
 {
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(*pXmlHandle, "NodeId", m_nodeId));
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(*pXmlHandle, "ParentNodeId", m_parentNodeId));
@@ -253,7 +261,9 @@ AdaBoostDecisionTree::Node::~Node()
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-AdaBoostDecisionTree::WeakClassifier::WeakClassifier(const TiXmlHandle *const pXmlHandle) : m_weight(0.), m_treeId(0)
+AdaBoostDecisionTree::WeakClassifier::WeakClassifier(const TiXmlHandle *const pXmlHandle) :
+    m_weight(0.),
+    m_treeId(0)
 {
     for (TiXmlElement *pHeadTiXmlElement = pXmlHandle->FirstChildElement().ToElement(); pHeadTiXmlElement != NULL;
          pHeadTiXmlElement = pHeadTiXmlElement->NextSiblingElement())
@@ -277,7 +287,9 @@ AdaBoostDecisionTree::WeakClassifier::WeakClassifier(const TiXmlHandle *const pX
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-AdaBoostDecisionTree::WeakClassifier::WeakClassifier(const WeakClassifier &rhs) : m_weight(rhs.m_weight), m_treeId(rhs.m_treeId)
+AdaBoostDecisionTree::WeakClassifier::WeakClassifier(const WeakClassifier &rhs) :
+    m_weight(rhs.m_weight),
+    m_treeId(rhs.m_treeId)
 {
     for (const auto &mapEntry : rhs.m_idToNodeMap)
     {

--- a/larpandoracontent/LArObjects/LArCaloHit.h
+++ b/larpandoracontent/LArObjects/LArCaloHit.h
@@ -242,7 +242,8 @@ inline void LArCaloHit::SetShowerProbability(const float probability)
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline LArCaloHitFactory::LArCaloHitFactory(const unsigned int version) : m_version(version)
+inline LArCaloHitFactory::LArCaloHitFactory(const unsigned int version) :
+    m_version(version)
 {
 }
 

--- a/larpandoracontent/LArObjects/LArDiscreteProbabilityVector.cc
+++ b/larpandoracontent/LArObjects/LArDiscreteProbabilityVector.cc
@@ -17,7 +17,9 @@ namespace lar_content
 
 template <typename TX, typename TY>
 DiscreteProbabilityVector::DiscreteProbabilityVector(const InputData<TX, TY> &inputData, const TX xUpperBound, const bool useWidths) :
-    m_xUpperBound(static_cast<float>(xUpperBound)), m_useWidths(useWidths), m_discreteProbabilityData(this->InitialiseDiscreteProbabilityData(inputData))
+    m_xUpperBound(static_cast<float>(xUpperBound)),
+    m_useWidths(useWidths),
+    m_discreteProbabilityData(this->InitialiseDiscreteProbabilityData(inputData))
 {
     this->VerifyCompleteData();
 }

--- a/larpandoracontent/LArObjects/LArDiscreteProbabilityVector.h
+++ b/larpandoracontent/LArObjects/LArDiscreteProbabilityVector.h
@@ -328,7 +328,10 @@ inline void DiscreteProbabilityVector::GetAllAtIndex(
 
 inline DiscreteProbabilityVector::DiscreteProbabilityDatum::DiscreteProbabilityDatum(
     const float x, const float densityDatum, const float cumulativeDatum, const float width) :
-    m_x(x), m_densityDatum(densityDatum), m_cumulativeDatum(cumulativeDatum), m_width(width)
+    m_x(x),
+    m_densityDatum(densityDatum),
+    m_cumulativeDatum(cumulativeDatum),
+    m_width(width)
 {
 }
 

--- a/larpandoracontent/LArObjects/LArMCParticle.h
+++ b/larpandoracontent/LArObjects/LArMCParticle.h
@@ -181,7 +181,9 @@ private:
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline LArMCParticle::LArMCParticle(const LArMCParticleParameters &parameters) :
-    object_creation::MCParticle::Object(parameters), m_nuanceCode(parameters.m_nuanceCode.Get()), m_process(parameters.m_process.Get())
+    object_creation::MCParticle::Object(parameters),
+    m_nuanceCode(parameters.m_nuanceCode.Get()),
+    m_process(parameters.m_process.Get())
 {
 }
 
@@ -218,7 +220,8 @@ inline MCProcess LArMCParticle::GetProcess() const
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline LArMCParticleFactory::LArMCParticleFactory(const unsigned int version) : m_version(version)
+inline LArMCParticleFactory::LArMCParticleFactory(const unsigned int version) :
+    m_version(version)
 {
 }
 

--- a/larpandoracontent/LArObjects/LArMvaInterface.h
+++ b/larpandoracontent/LArObjects/LArMvaInterface.h
@@ -128,20 +128,25 @@ public:
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline MvaTypes::InitializedDouble::InitializedDouble() : m_number(0.), m_isInitialized(false)
+inline MvaTypes::InitializedDouble::InitializedDouble() :
+    m_number(0.),
+    m_isInitialized(false)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline MvaTypes::InitializedDouble::InitializedDouble(const double number) : m_number(number), m_isInitialized(true)
+inline MvaTypes::InitializedDouble::InitializedDouble(const double number) :
+    m_number(number),
+    m_isInitialized(true)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline MvaTypes::InitializedDouble::InitializedDouble(const InitializedDouble &rhs) :
-    m_number(rhs.m_number), m_isInitialized(rhs.m_isInitialized)
+    m_number(rhs.m_number),
+    m_isInitialized(rhs.m_isInitialized)
 {
 }
 

--- a/larpandoracontent/LArObjects/LArOverlapMatrix.h
+++ b/larpandoracontent/LArObjects/LArOverlapMatrix.h
@@ -335,7 +335,9 @@ inline void OverlapMatrix<T>::Clear()
 template <typename T>
 inline OverlapMatrix<T>::Element::Element(
     const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2, const OverlapResult &overlapResult) :
-    m_pCluster1(pCluster1), m_pCluster2(pCluster2), m_overlapResult(overlapResult)
+    m_pCluster1(pCluster1),
+    m_pCluster2(pCluster2),
+    m_overlapResult(overlapResult)
 {
 }
 

--- a/larpandoracontent/LArObjects/LArOverlapTensor.cc
+++ b/larpandoracontent/LArObjects/LArOverlapTensor.cc
@@ -304,9 +304,9 @@ void OverlapTensor<T>::ExploreConnections(const Cluster *const pCluster, const b
         throw StatusCodeException(STATUS_CODE_FAILURE);
 
     ClusterList &clusterList((TPC_VIEW_U == hitType) ? clusterListU : (TPC_VIEW_V == hitType) ? clusterListV : clusterListW);
-    const ClusterNavigationMap &navigationMap((TPC_VIEW_U == hitType)   ? m_clusterNavigationMapUV
-                                              : (TPC_VIEW_V == hitType) ? m_clusterNavigationMapVW
-                                                                        : m_clusterNavigationMapWU);
+    const ClusterNavigationMap &navigationMap((TPC_VIEW_U == hitType) ? m_clusterNavigationMapUV
+            : (TPC_VIEW_V == hitType)                                 ? m_clusterNavigationMapVW
+                                                                      : m_clusterNavigationMapWU);
 
     if (clusterList.end() != std::find(clusterList.begin(), clusterList.end(), pCluster))
         return;

--- a/larpandoracontent/LArObjects/LArOverlapTensor.h
+++ b/larpandoracontent/LArObjects/LArOverlapTensor.h
@@ -411,7 +411,10 @@ inline void OverlapTensor<T>::Clear()
 template <typename T>
 inline OverlapTensor<T>::Element::Element(const pandora::Cluster *const pClusterU, const pandora::Cluster *const pClusterV,
     const pandora::Cluster *const pClusterW, const OverlapResult &overlapResult) :
-    m_pClusterU(pClusterU), m_pClusterV(pClusterV), m_pClusterW(pClusterW), m_overlapResult(overlapResult)
+    m_pClusterU(pClusterU),
+    m_pClusterV(pClusterV),
+    m_pClusterW(pClusterW),
+    m_overlapResult(overlapResult)
 {
 }
 

--- a/larpandoracontent/LArObjects/LArPfoObjects.cc
+++ b/larpandoracontent/LArObjects/LArPfoObjects.cc
@@ -16,14 +16,16 @@ namespace lar_content
 {
 
 LArTrackState::LArTrackState(const CartesianVector &position, const CartesianVector &direction, const CaloHit *const pCaloHit) :
-    TrackState(position, direction), m_pCaloHit(pCaloHit)
+    TrackState(position, direction),
+    m_pCaloHit(pCaloHit)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 LArTrackState::LArTrackState(const CartesianVector &position, const CartesianVector &direction) :
-    TrackState(position, direction), m_pCaloHit(nullptr)
+    TrackState(position, direction),
+    m_pCaloHit(nullptr)
 {
 }
 

--- a/larpandoracontent/LArObjects/LArPfoObjects.h
+++ b/larpandoracontent/LArObjects/LArPfoObjects.h
@@ -200,14 +200,16 @@ private:
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline LArTrackTrajectoryPoint::LArTrackTrajectoryPoint(const float projectedDistance, const LArTrackState &larTrackState) :
-    std::pair<float, LArTrackState>(projectedDistance, larTrackState), m_index(-1)
+    std::pair<float, LArTrackState>(projectedDistance, larTrackState),
+    m_index(-1)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline LArTrackTrajectoryPoint::LArTrackTrajectoryPoint(const float projectedDistance, const LArTrackState &larTrackState, const int index) :
-    std::pair<float, LArTrackState>(projectedDistance, larTrackState), m_index(index)
+    std::pair<float, LArTrackState>(projectedDistance, larTrackState),
+    m_index(index)
 {
 }
 

--- a/larpandoracontent/LArObjects/LArPointingCluster.cc
+++ b/larpandoracontent/LArObjects/LArPointingCluster.cc
@@ -79,7 +79,7 @@ void LArPointingCluster::BuildPointingCluster(const ThreeDSlidingFitResult &slid
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
     const bool isInner((slidingFitResult.GetGlobalMinLayerPosition().GetZ() < slidingFitResult.GetGlobalMaxLayerPosition().GetZ()) &&
-                       (slidingFitResult.GetMinLayer() < slidingFitResult.GetMaxLayer()));
+        (slidingFitResult.GetMinLayer() < slidingFitResult.GetMaxLayer()));
 
     m_pCluster = slidingFitResult.GetCluster();
 
@@ -95,7 +95,12 @@ void LArPointingCluster::BuildPointingCluster(const ThreeDSlidingFitResult &slid
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 LArPointingCluster::Vertex::Vertex() :
-    m_pCluster(NULL), m_position(0.f, 0.f, 0.f), m_direction(0.f, 0.f, 0.f), m_rms(std::numeric_limits<float>::max()), m_isInner(false), m_isInitialized(false)
+    m_pCluster(NULL),
+    m_position(0.f, 0.f, 0.f),
+    m_direction(0.f, 0.f, 0.f),
+    m_rms(std::numeric_limits<float>::max()),
+    m_isInner(false),
+    m_isInitialized(false)
 {
 }
 
@@ -103,14 +108,24 @@ LArPointingCluster::Vertex::Vertex() :
 
 LArPointingCluster::Vertex::Vertex(
     const Cluster *const pCluster, const CartesianVector &position, const CartesianVector &direction, const float rms, const bool isInner) :
-    m_pCluster(pCluster), m_position(position), m_direction(direction), m_rms(rms), m_isInner(isInner), m_isInitialized(true)
+    m_pCluster(pCluster),
+    m_position(position),
+    m_direction(direction),
+    m_rms(rms),
+    m_isInner(isInner),
+    m_isInitialized(true)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 LArPointingCluster::Vertex::Vertex(const Vertex &rhs) :
-    m_pCluster(rhs.m_pCluster), m_position(rhs.m_position), m_direction(rhs.m_direction), m_rms(rhs.m_rms), m_isInner(rhs.m_isInner), m_isInitialized(rhs.m_isInitialized)
+    m_pCluster(rhs.m_pCluster),
+    m_position(rhs.m_position),
+    m_direction(rhs.m_direction),
+    m_rms(rhs.m_rms),
+    m_isInner(rhs.m_isInner),
+    m_isInitialized(rhs.m_isInitialized)
 {
 }
 

--- a/larpandoracontent/LArObjects/LArShowerOverlapResult.cc
+++ b/larpandoracontent/LArObjects/LArShowerOverlapResult.cc
@@ -29,7 +29,11 @@ ShowerOverlapResult::ShowerOverlapResult() :
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 ShowerOverlapResult::ShowerOverlapResult(const unsigned int nMatchedSamplingPoints, const unsigned int nSamplingPoints, const XOverlap &xOverlap) :
-    m_isInitialized(true), m_nMatchedSamplingPoints(nMatchedSamplingPoints), m_nSamplingPoints(nSamplingPoints), m_matchedFraction(0.f), m_xOverlap(xOverlap)
+    m_isInitialized(true),
+    m_nMatchedSamplingPoints(nMatchedSamplingPoints),
+    m_nSamplingPoints(nSamplingPoints),
+    m_matchedFraction(0.f),
+    m_xOverlap(xOverlap)
 {
     if ((0 == m_nSamplingPoints) || (m_nMatchedSamplingPoints > m_nSamplingPoints))
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);

--- a/larpandoracontent/LArObjects/LArSupportVectorMachine.cc
+++ b/larpandoracontent/LArObjects/LArSupportVectorMachine.cc
@@ -274,8 +274,8 @@ double SupportVectorMachine::CalculateClassificationScoreImpl(const LArMvaHelper
     double classScore(0.);
     for (const SupportVectorInfo &supportVectorInfo : m_svInfoList)
     {
-        classScore += supportVectorInfo.m_yAlpha * m_kernelFunction(supportVectorInfo.m_supportVector,
-                                                       (m_standardizeFeatures ? standardizedFeatures : features), m_scaleFactor);
+        classScore += supportVectorInfo.m_yAlpha *
+            m_kernelFunction(supportVectorInfo.m_supportVector, (m_standardizeFeatures ? standardizedFeatures : features), m_scaleFactor);
     }
 
     return classScore + m_bias;

--- a/larpandoracontent/LArObjects/LArSupportVectorMachine.h
+++ b/larpandoracontent/LArObjects/LArSupportVectorMachine.h
@@ -400,20 +400,24 @@ inline double SupportVectorMachine::GaussianRbfKernel(
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline SupportVectorMachine::SupportVectorInfo::SupportVectorInfo(const double yAlpha, LArMvaHelper::MvaFeatureVector supportVector) :
-    m_yAlpha(yAlpha), m_supportVector(std::move(supportVector))
+    m_yAlpha(yAlpha),
+    m_supportVector(std::move(supportVector))
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline SupportVectorMachine::FeatureInfo::FeatureInfo(const double muValue, const double sigmaValue) :
-    m_muValue(muValue), m_sigmaValue(sigmaValue)
+    m_muValue(muValue),
+    m_sigmaValue(sigmaValue)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline SupportVectorMachine::FeatureInfo::FeatureInfo() : m_muValue(0.), m_sigmaValue(0.)
+inline SupportVectorMachine::FeatureInfo::FeatureInfo() :
+    m_muValue(0.),
+    m_sigmaValue(0.)
 {
 }
 

--- a/larpandoracontent/LArObjects/LArThreeDSlidingConeFitResult.h
+++ b/larpandoracontent/LArObjects/LArThreeDSlidingConeFitResult.h
@@ -172,7 +172,10 @@ typedef std::unordered_map<const pandora::Cluster *, ThreeDSlidingConeFitResult>
 
 inline SimpleCone::SimpleCone(const pandora::CartesianVector &coneApex, const pandora::CartesianVector &coneDirection,
     const float coneLength, const float coneTanHalfAngle) :
-    m_coneApex(coneApex), m_coneDirection(coneDirection), m_coneLength(coneLength), m_coneTanHalfAngle(coneTanHalfAngle)
+    m_coneApex(coneApex),
+    m_coneDirection(coneDirection),
+    m_coneLength(coneLength),
+    m_coneTanHalfAngle(coneTanHalfAngle)
 {
 }
 

--- a/larpandoracontent/LArObjects/LArTrackOverlapResult.cc
+++ b/larpandoracontent/LArObjects/LArTrackOverlapResult.cc
@@ -18,7 +18,12 @@ namespace lar_content
 {
 
 TrackOverlapResult::TrackOverlapResult() :
-    m_isInitialized(false), m_nMatchedSamplingPoints(0), m_nSamplingPoints(0), m_matchedFraction(0.f), m_chi2(0.f), m_reducedChi2(0.f)
+    m_isInitialized(false),
+    m_nMatchedSamplingPoints(0),
+    m_nSamplingPoints(0),
+    m_matchedFraction(0.f),
+    m_chi2(0.f),
+    m_reducedChi2(0.f)
 {
 }
 
@@ -112,7 +117,9 @@ TrackOverlapResult &TrackOverlapResult::operator=(const TrackOverlapResult &rhs)
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-TransverseOverlapResult::TransverseOverlapResult() : TrackOverlapResult(), m_xOverlap(XOverlap(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f))
+TransverseOverlapResult::TransverseOverlapResult() :
+    TrackOverlapResult(),
+    m_xOverlap(XOverlap(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f))
 {
 }
 
@@ -120,14 +127,16 @@ TransverseOverlapResult::TransverseOverlapResult() : TrackOverlapResult(), m_xOv
 
 TransverseOverlapResult::TransverseOverlapResult(
     const unsigned int nMatchedSamplingPoints, const unsigned int nSamplingPoints, const float chi2, const XOverlap &xOverlap) :
-    TrackOverlapResult(nMatchedSamplingPoints, nSamplingPoints, chi2), m_xOverlap(xOverlap)
+    TrackOverlapResult(nMatchedSamplingPoints, nSamplingPoints, chi2),
+    m_xOverlap(xOverlap)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 TransverseOverlapResult::TransverseOverlapResult(const TransverseOverlapResult &rhs) :
-    TrackOverlapResult(rhs), m_xOverlap(rhs.IsInitialized() ? rhs.GetXOverlap() : XOverlap(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f))
+    TrackOverlapResult(rhs),
+    m_xOverlap(rhs.IsInitialized() ? rhs.GetXOverlap() : XOverlap(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f))
 {
 }
 
@@ -176,13 +185,18 @@ TransverseOverlapResult operator+(const TransverseOverlapResult &lhs, const Tran
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-LongitudinalOverlapResult::LongitudinalOverlapResult() : TrackOverlapResult(), m_innerChi2(0.f), m_outerChi2(0.f)
+LongitudinalOverlapResult::LongitudinalOverlapResult() :
+    TrackOverlapResult(),
+    m_innerChi2(0.f),
+    m_outerChi2(0.f)
 {
 }
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 LongitudinalOverlapResult::LongitudinalOverlapResult(const TrackOverlapResult trackOverlapResult, const float innerChi2, const float outerChi2) :
-    TrackOverlapResult(trackOverlapResult), m_innerChi2(innerChi2), m_outerChi2(outerChi2)
+    TrackOverlapResult(trackOverlapResult),
+    m_innerChi2(innerChi2),
+    m_outerChi2(outerChi2)
 {
 }
 
@@ -190,14 +204,18 @@ LongitudinalOverlapResult::LongitudinalOverlapResult(const TrackOverlapResult tr
 
 LongitudinalOverlapResult::LongitudinalOverlapResult(const unsigned int nMatchedSamplingPoints, const unsigned int nSamplingPoints,
     const float chi2, const float innerChi2, const float outerChi2) :
-    TrackOverlapResult(nMatchedSamplingPoints, nSamplingPoints, chi2), m_innerChi2(innerChi2), m_outerChi2(outerChi2)
+    TrackOverlapResult(nMatchedSamplingPoints, nSamplingPoints, chi2),
+    m_innerChi2(innerChi2),
+    m_outerChi2(outerChi2)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 LongitudinalOverlapResult::LongitudinalOverlapResult(const LongitudinalOverlapResult &rhs) :
-    TrackOverlapResult(rhs), m_innerChi2(rhs.IsInitialized() ? rhs.GetInnerChi2() : 0.f), m_outerChi2(rhs.IsInitialized() ? rhs.GetOuterChi2() : 0.f)
+    TrackOverlapResult(rhs),
+    m_innerChi2(rhs.IsInitialized() ? rhs.GetInnerChi2() : 0.f),
+    m_outerChi2(rhs.IsInitialized() ? rhs.GetOuterChi2() : 0.f)
 {
 }
 
@@ -221,14 +239,19 @@ LongitudinalOverlapResult &LongitudinalOverlapResult::operator=(const Longitudin
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-FragmentOverlapResult::FragmentOverlapResult() : TrackOverlapResult(), m_caloHitList(), m_clusterList()
+FragmentOverlapResult::FragmentOverlapResult() :
+    TrackOverlapResult(),
+    m_caloHitList(),
+    m_clusterList()
 {
 }
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 FragmentOverlapResult::FragmentOverlapResult(
     const TrackOverlapResult trackOverlapResult, const pandora::CaloHitList &caloHitList, const pandora::ClusterList &clusterList) :
-    TrackOverlapResult(trackOverlapResult), m_caloHitList(caloHitList), m_clusterList(clusterList)
+    TrackOverlapResult(trackOverlapResult),
+    m_caloHitList(caloHitList),
+    m_clusterList(clusterList)
 {
 }
 
@@ -236,7 +259,9 @@ FragmentOverlapResult::FragmentOverlapResult(
 
 FragmentOverlapResult::FragmentOverlapResult(const unsigned int nMatchedSamplingPoints, const unsigned int nSamplingPoints,
     const float chi2, const pandora::CaloHitList &caloHitList, const pandora::ClusterList &clusterList) :
-    TrackOverlapResult(nMatchedSamplingPoints, nSamplingPoints, chi2), m_caloHitList(caloHitList), m_clusterList(clusterList)
+    TrackOverlapResult(nMatchedSamplingPoints, nSamplingPoints, chi2),
+    m_caloHitList(caloHitList),
+    m_clusterList(clusterList)
 {
 }
 
@@ -279,7 +304,9 @@ pandora::HitType FragmentOverlapResult::GetFragmentHitType() const
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-DeltaRayOverlapResult::DeltaRayOverlapResult() : TransverseOverlapResult(), m_commonMuonPfoList(PfoList())
+DeltaRayOverlapResult::DeltaRayOverlapResult() :
+    TransverseOverlapResult(),
+    m_commonMuonPfoList(PfoList())
 {
 }
 
@@ -287,14 +314,16 @@ DeltaRayOverlapResult::DeltaRayOverlapResult() : TransverseOverlapResult(), m_co
 
 DeltaRayOverlapResult::DeltaRayOverlapResult(const unsigned int nMatchedSamplingPoints, const unsigned int nSamplingPoints,
     const float chi2, const XOverlap &xOverlap, const PfoList &commonMuonPfoList) :
-    TransverseOverlapResult(nMatchedSamplingPoints, nSamplingPoints, chi2, xOverlap), m_commonMuonPfoList(commonMuonPfoList)
+    TransverseOverlapResult(nMatchedSamplingPoints, nSamplingPoints, chi2, xOverlap),
+    m_commonMuonPfoList(commonMuonPfoList)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 DeltaRayOverlapResult::DeltaRayOverlapResult(const DeltaRayOverlapResult &rhs) :
-    TransverseOverlapResult(rhs), m_commonMuonPfoList(rhs.GetCommonMuonPfoList())
+    TransverseOverlapResult(rhs),
+    m_commonMuonPfoList(rhs.GetCommonMuonPfoList())
 {
 }
 

--- a/larpandoracontent/LArObjects/LArTrackPfo.cc
+++ b/larpandoracontent/LArObjects/LArTrackPfo.cc
@@ -16,7 +16,8 @@ namespace lar_content
 {
 
 LArTrackPfo::LArTrackPfo(const LArTrackPfoParameters &parameters) :
-    ParticleFlowObject(parameters), m_trackStateVector(parameters.m_trackStateVector)
+    ParticleFlowObject(parameters),
+    m_trackStateVector(parameters.m_trackStateVector)
 {
 }
 

--- a/larpandoracontent/LArObjects/LArTrackTwoViewOverlapResult.cc
+++ b/larpandoracontent/LArObjects/LArTrackTwoViewOverlapResult.cc
@@ -113,20 +113,25 @@ bool TwoViewDeltaRayOverlapResult::operator<(const TwoViewDeltaRayOverlapResult 
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-TrackTwoViewOverlapResult::TrackTwoViewOverlapResult() : m_isInitialized(false), m_matchingScore(0)
+TrackTwoViewOverlapResult::TrackTwoViewOverlapResult() :
+    m_isInitialized(false),
+    m_matchingScore(0)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-TrackTwoViewOverlapResult::TrackTwoViewOverlapResult(const float matchingScore) : m_isInitialized(true), m_matchingScore(matchingScore)
+TrackTwoViewOverlapResult::TrackTwoViewOverlapResult(const float matchingScore) :
+    m_isInitialized(true),
+    m_matchingScore(matchingScore)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 TrackTwoViewOverlapResult::TrackTwoViewOverlapResult(const TrackTwoViewOverlapResult &rhs) :
-    m_isInitialized(rhs.m_isInitialized), m_matchingScore(rhs.m_matchingScore)
+    m_isInitialized(rhs.m_isInitialized),
+    m_matchingScore(rhs.m_matchingScore)
 {
 }
 

--- a/larpandoracontent/LArObjects/LArTwoDSlidingFitObjects.h
+++ b/larpandoracontent/LArObjects/LArTwoDSlidingFitObjects.h
@@ -293,7 +293,10 @@ typedef std::vector<FitSegment> FitSegmentList;
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline LayerFitResult::LayerFitResult(const double l, const double fitT, const double gradient, const double rms) :
-    m_l(l), m_fitT(fitT), m_gradient(gradient), m_rms(rms)
+    m_l(l),
+    m_fitT(fitT),
+    m_gradient(gradient),
+    m_rms(rms)
 {
 }
 
@@ -328,7 +331,13 @@ inline double LayerFitResult::GetRms() const
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline LayerFitContribution::LayerFitContribution() : m_sumT(0.), m_sumL(0.), m_sumTT(0.), m_sumLT(0.), m_sumLL(0.), m_nPoints(0)
+inline LayerFitContribution::LayerFitContribution() :
+    m_sumT(0.),
+    m_sumL(0.),
+    m_sumTT(0.),
+    m_sumLT(0.),
+    m_sumLL(0.),
+    m_nPoints(0)
 {
 }
 
@@ -392,7 +401,10 @@ inline unsigned int LayerFitContribution::GetNPoints() const
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline LayerInterpolation::LayerInterpolation() : m_isInitialized(false), m_startLayerWeight(0.f), m_endLayerWeight(0.f)
+inline LayerInterpolation::LayerInterpolation() :
+    m_isInitialized(false),
+    m_startLayerWeight(0.f),
+    m_endLayerWeight(0.f)
 {
 }
 
@@ -400,7 +412,11 @@ inline LayerInterpolation::LayerInterpolation() : m_isInitialized(false), m_star
 
 inline LayerInterpolation::LayerInterpolation(const LayerFitResultMap::const_iterator &startLayerIter,
     const LayerFitResultMap::const_iterator &endLayerIter, const double startLayerWeight, const double endLayerWeight) :
-    m_isInitialized(true), m_startLayerIter(startLayerIter), m_endLayerIter(endLayerIter), m_startLayerWeight(startLayerWeight), m_endLayerWeight(endLayerWeight)
+    m_isInitialized(true),
+    m_startLayerIter(startLayerIter),
+    m_endLayerIter(endLayerIter),
+    m_startLayerWeight(startLayerWeight),
+    m_endLayerWeight(endLayerWeight)
 {
 }
 
@@ -455,7 +471,8 @@ inline double LayerInterpolation::GetEndLayerWeight() const
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline FitSegment::FitSegment(const int startLayer, const int endLayer, const double startX, const double endX) :
-    m_startLayer(startLayer), m_endLayer(endLayer)
+    m_startLayer(startLayer),
+    m_endLayer(endLayer)
 {
     m_minX = std::min(startX, endX);
     m_maxX = std::max(startX, endX);

--- a/larpandoracontent/LArObjects/LArTwoDSlidingFitResult.cc
+++ b/larpandoracontent/LArObjects/LArTwoDSlidingFitResult.cc
@@ -719,7 +719,7 @@ void TwoDSlidingFitResult::PerformSlidingLinearFit()
         double variance((slidingSumTT - 2. * intercept * slidingSumT - 2. * gradient * slidingSumLT +
                             intercept * intercept * static_cast<double>(slidingNPoints) + 2. * gradient * intercept * slidingSumL +
                             gradient * gradient * slidingSumLL) /
-                        (1. + gradient * gradient));
+            (1. + gradient * gradient));
 
         if (variance < -std::numeric_limits<float>::epsilon())
             continue;

--- a/larpandoracontent/LArObjects/LArTwoDSlidingShowerFitResult.h
+++ b/larpandoracontent/LArObjects/LArTwoDSlidingShowerFitResult.h
@@ -187,7 +187,9 @@ inline const TwoDSlidingFitResult &TwoDSlidingShowerFitResult::GetPositiveEdgeFi
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline ShowerExtent::ShowerExtent(const float xCoordinate, const float edge1, const float edge2) :
-    m_xCoordinate(xCoordinate), m_highEdgeZ(std::max(edge1, edge2)), m_lowEdgeZ(std::min(edge1, edge2))
+    m_xCoordinate(xCoordinate),
+    m_highEdgeZ(std::max(edge1, edge2)),
+    m_lowEdgeZ(std::min(edge1, edge2))
 {
 }
 

--- a/larpandoracontent/LArObjects/LArTwoViewXOverlap.h
+++ b/larpandoracontent/LArObjects/LArTwoViewXOverlap.h
@@ -127,7 +127,11 @@ TwoViewXOverlap operator+(const TwoViewXOverlap &lhs, const TwoViewXOverlap &rhs
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline TwoViewXOverlap::TwoViewXOverlap(const float xMin0, const float xMax0, const float xMin1, const float xMax1) :
-    m_xMin0(xMin0), m_xMax0(xMax0), m_xMin1(xMin1), m_xMax1(xMax1), m_xOverlapSpan(std::min(m_xMax0, m_xMax1) - std::max(m_xMin0, m_xMin1))
+    m_xMin0(xMin0),
+    m_xMax0(xMax0),
+    m_xMin1(xMin1),
+    m_xMax1(xMax1),
+    m_xOverlapSpan(std::min(m_xMax0, m_xMax1) - std::max(m_xMin0, m_xMin1))
 {
 }
 

--- a/larpandoracontent/LArObjects/LArXOverlap.h
+++ b/larpandoracontent/LArObjects/LArXOverlap.h
@@ -122,7 +122,13 @@ XOverlap operator+(const XOverlap &lhs, const XOverlap &rhs);
 
 inline XOverlap::XOverlap(const float uMinX, const float uMaxX, const float vMinX, const float vMaxX, const float wMinX, const float wMaxX,
     const float xOverlapSpan) :
-    m_uMinX(uMinX), m_uMaxX(uMaxX), m_vMinX(vMinX), m_vMaxX(vMaxX), m_wMinX(wMinX), m_wMaxX(wMaxX), m_xOverlapSpan(xOverlapSpan)
+    m_uMinX(uMinX),
+    m_uMaxX(uMaxX),
+    m_vMinX(vMinX),
+    m_vMaxX(vMaxX),
+    m_wMinX(wMinX),
+    m_wMaxX(wMaxX),
+    m_xOverlapSpan(xOverlapSpan)
 {
 }
 

--- a/larpandoracontent/LArPersistency/EventReadingAlgorithm.cc
+++ b/larpandoracontent/LArPersistency/EventReadingAlgorithm.cc
@@ -24,7 +24,12 @@ namespace lar_content
 {
 
 EventReadingAlgorithm::EventReadingAlgorithm() :
-    m_skipToEvent(0), m_useLArCaloHits(true), m_larCaloHitVersion(1), m_useLArMCParticles(true), m_larMCParticleVersion(2), m_pEventFileReader(nullptr)
+    m_skipToEvent(0),
+    m_useLArCaloHits(true),
+    m_larCaloHitVersion(1),
+    m_useLArMCParticles(true),
+    m_larMCParticleVersion(2),
+    m_pEventFileReader(nullptr)
 {
 }
 

--- a/larpandoracontent/LArPlugins/LArParticleIdPlugins.cc
+++ b/larpandoracontent/LArPlugins/LArParticleIdPlugins.cc
@@ -27,7 +27,11 @@ namespace lar_content
 using namespace pandora;
 
 LArParticleIdPlugins::LArMuonId::LArMuonId() :
-    m_layerFitHalfWindow(20), m_minLayerOccupancy(0.75f), m_maxTrackWidth(0.5f), m_trackResidualQuantile(0.8f), m_minClustersPassingId(2)
+    m_layerFitHalfWindow(20),
+    m_minLayerOccupancy(0.75f),
+    m_maxTrackWidth(0.5f),
+    m_trackResidualQuantile(0.8f),
+    m_minClustersPassingId(2)
 {
 }
 

--- a/larpandoracontent/LArPlugins/LArPseudoLayerPlugin.cc
+++ b/larpandoracontent/LArPlugins/LArPseudoLayerPlugin.cc
@@ -24,7 +24,10 @@ namespace lar_content
 
 using namespace pandora;
 
-LArPseudoLayerPlugin::LArPseudoLayerPlugin() : m_zPitch(std::numeric_limits<float>::max()), m_zOffset(0.01f), m_zerothLayer(5000)
+LArPseudoLayerPlugin::LArPseudoLayerPlugin() :
+    m_zPitch(std::numeric_limits<float>::max()),
+    m_zOffset(0.01f),
+    m_zerothLayer(5000)
 {
 }
 

--- a/larpandoracontent/LArPlugins/LArRotationalTransformationPlugin.cc
+++ b/larpandoracontent/LArPlugins/LArRotationalTransformationPlugin.cc
@@ -267,7 +267,7 @@ void LArRotationalTransformationPlugin::GetMinChiSquaredYZ(const double u, const
     const double deltaUFit(uFit - outputU), deltaVFit(vFit - outputV), deltaWFit(wFit - outputW);
 
     chiSquared = ((deltaU * deltaU) / sigmaU2) + ((deltaV * deltaV) / sigmaV2) + ((deltaW * deltaW) / sigmaW2) +
-                 ((deltaUFit * deltaUFit) / sigmaFit2) + ((deltaVFit * deltaVFit) / sigmaFit2) + ((deltaWFit * deltaWFit) / sigmaFit2);
+        ((deltaUFit * deltaUFit) / sigmaFit2) + ((deltaVFit * deltaVFit) / sigmaFit2) + ((deltaWFit * deltaWFit) / sigmaFit2);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArShowerRefinement/ConnectionPathwayFeatureTool.cc
+++ b/larpandoracontent/LArShowerRefinement/ConnectionPathwayFeatureTool.cc
@@ -23,7 +23,10 @@ namespace lar_content
 {
 
 InitialRegionFeatureTool::InitialRegionFeatureTool() :
-    m_defaultFloat(-10.f), m_nHitsToConsider(10), m_maxInitialGapSizeLimit(4.f), m_minLargestGapSizeLimit(2.f)
+    m_defaultFloat(-10.f),
+    m_nHitsToConsider(10),
+    m_maxInitialGapSizeLimit(4.f),
+    m_minLargestGapSizeLimit(2.f)
 {
 }
 
@@ -82,8 +85,8 @@ void InitialRegionFeatureTool::GetViewInitialRegionVariables(const Algorithm *co
     const ProtoShowerMatch &protoShowerMatch, const HitType hitType, float &initialGapSize, float &largestGapSize) const
 {
     const ProtoShower &protoShower(hitType == TPC_VIEW_U
-                                       ? protoShowerMatch.GetProtoShowerU()
-                                       : (hitType == TPC_VIEW_V ? protoShowerMatch.GetProtoShowerV() : protoShowerMatch.GetProtoShowerW()));
+            ? protoShowerMatch.GetProtoShowerU()
+            : (hitType == TPC_VIEW_V ? protoShowerMatch.GetProtoShowerV() : protoShowerMatch.GetProtoShowerW()));
     const CartesianVector nuVertex2D(LArGeometryHelper::ProjectPosition(pAlgorithm->GetPandora(), nuVertex3D, hitType));
     const CartesianVector &startDirection(protoShower.GetConnectionPathway().GetStartDirection());
 
@@ -130,7 +133,11 @@ StatusCode InitialRegionFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 ConnectionRegionFeatureTool::ConnectionRegionFeatureTool() :
-    m_defaultFloat(-10.f), m_spineFitWindow(10), m_nLayersHalfWindow(5), m_pathwayLengthLimit(30.f), m_pathwayScatteringAngle2DLimit(10.f)
+    m_defaultFloat(-10.f),
+    m_spineFitWindow(10),
+    m_nLayersHalfWindow(5),
+    m_pathwayLengthLimit(30.f),
+    m_pathwayScatteringAngle2DLimit(10.f)
 {
 }
 
@@ -186,9 +193,9 @@ float ConnectionRegionFeatureTool::Get2DKink(
 
         for (HitType hitType : {TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W})
         {
-            const ProtoShower &protoShower(
-                hitType == TPC_VIEW_U ? protoShowerMatch.GetProtoShowerU()
-                                      : (hitType == TPC_VIEW_V ? protoShowerMatch.GetProtoShowerV() : protoShowerMatch.GetProtoShowerW()));
+            const ProtoShower &protoShower(hitType == TPC_VIEW_U
+                    ? protoShowerMatch.GetProtoShowerU()
+                    : (hitType == TPC_VIEW_V ? protoShowerMatch.GetProtoShowerV() : protoShowerMatch.GetProtoShowerW()));
             CartesianPointVector &spinePositions(hitType == TPC_VIEW_U ? spinePositionsU : (hitType == TPC_VIEW_V ? spinePositionsV : spinePositionsW));
 
             for (const CaloHit *const pCaloHit : protoShower.GetSpineHitList())
@@ -530,7 +537,7 @@ void ShowerRegionFeatureTool::GetViewShowerRegionVariables(const Algorithm *cons
             &postShowerPositions, m_showerFitWindow, LArGeometryHelper::GetWirePitch(pAlgorithm->GetPandora(), hitType));
 
         const bool isShowerDownstream((showerStart2D - showerFitResult.GetGlobalMinLayerPosition()).GetMagnitude() <
-                                      (showerStart2D - showerFitResult.GetGlobalMaxLayerPosition()).GetMagnitude());
+            (showerStart2D - showerFitResult.GetGlobalMaxLayerPosition()).GetMagnitude());
 
         // Collect more hits
         for (const CaloHit *const pCaloHit : viewHitList)
@@ -642,7 +649,7 @@ void ShowerRegionFeatureTool::CalculateViewScatterAngle(const CartesianVector &n
         isDownstream ? spineFitResult.GetGlobalMinLayerDirection() : spineFitResult.GetGlobalMaxLayerDirection() * (-1.f));
 
     const bool isShowerDownstream((showerStart2D - showerFitResult.GetGlobalMinLayerPosition()).GetMagnitude() <
-                                  (showerStart2D - showerFitResult.GetGlobalMaxLayerPosition()).GetMagnitude());
+        (showerStart2D - showerFitResult.GetGlobalMaxLayerPosition()).GetMagnitude());
     const CartesianVector streamCorrectedShowerDirection(
         isShowerDownstream ? showerFitResult.GetGlobalMinLayerDirection() : showerFitResult.GetGlobalMaxLayerDirection() * (-1.f));
 
@@ -950,8 +957,8 @@ bool AmbiguousRegionFeatureTool::GetViewAmbiguousHitVariables(const Algorithm *c
     CaloHitList hitsToExcludeInEnergyCalcs; // to avoid double  counting
     const CartesianVector nuVertex2D(LArGeometryHelper::ProjectPosition(pAlgorithm->GetPandora(), nuVertex3D, hitType));
     const ProtoShower &protoShower(hitType == TPC_VIEW_U
-                                       ? protoShowerMatch.GetProtoShowerU()
-                                       : (hitType == TPC_VIEW_V ? protoShowerMatch.GetProtoShowerV() : protoShowerMatch.GetProtoShowerW()));
+            ? protoShowerMatch.GetProtoShowerU()
+            : (hitType == TPC_VIEW_V ? protoShowerMatch.GetProtoShowerV() : protoShowerMatch.GetProtoShowerW()));
 
     this->BuildAmbiguousSpines(pAlgorithm, hitType, protoShower, nuVertex2D, ambiguousHitSpines, hitsToExcludeInEnergyCalcs);
 
@@ -1084,9 +1091,9 @@ void AmbiguousRegionFeatureTool::BuildAmbiguousSpines(const Algorithm *const pAl
 
 StatusCode AmbiguousRegionFeatureTool::GetHitListOfType(const Algorithm *const pAlgorithm, const HitType hitType, const CaloHitList *&pCaloHitList) const
 {
-    const std::string typeHitListName(hitType == TPC_VIEW_U   ? m_caloHitListNameU
-                                      : hitType == TPC_VIEW_V ? m_caloHitListNameV
-                                                              : m_caloHitListNameW);
+    const std::string typeHitListName(hitType == TPC_VIEW_U ? m_caloHitListNameU
+            : hitType == TPC_VIEW_V                         ? m_caloHitListNameV
+                                                            : m_caloHitListNameW);
 
     PANDORA_THROW_RESULT_IF_AND_IF(
         STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*pAlgorithm, typeHitListName, pCaloHitList));

--- a/larpandoracontent/LArShowerRefinement/ElectronInitialRegionRefinementAlgorithm.cc
+++ b/larpandoracontent/LArShowerRefinement/ElectronInitialRegionRefinementAlgorithm.cc
@@ -267,9 +267,9 @@ void ElectronInitialRegionRefinementAlgorithm::BuildViewProtoShowers(const Parti
 
 StatusCode ElectronInitialRegionRefinementAlgorithm::GetHitListOfType(const HitType hitType, const CaloHitList *&pCaloHitList) const
 {
-    const std::string typeHitListName(hitType == TPC_VIEW_U   ? m_caloHitListNameU
-                                      : hitType == TPC_VIEW_V ? m_caloHitListNameV
-                                                              : m_caloHitListNameW);
+    const std::string typeHitListName(hitType == TPC_VIEW_U ? m_caloHitListNameU
+            : hitType == TPC_VIEW_V                         ? m_caloHitListNameV
+                                                            : m_caloHitListNameW);
 
     PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, typeHitListName, pCaloHitList));
 
@@ -615,7 +615,7 @@ void ElectronInitialRegionRefinementAlgorithm::FillElectronHitMap(HitOwnershipMa
             for (const MCParticle *const pMCParticle : contributingMCParticleVector)
             {
                 const bool isLeadingElectron((std::abs(pMCParticle->GetParticleId()) == 11) &&
-                                             (LArMCParticleHelper::GetPrimaryMCParticle(pMCParticle) == pMCParticle));
+                    (LArMCParticleHelper::GetPrimaryMCParticle(pMCParticle) == pMCParticle));
 
                 if (isLeadingElectron)
                 {

--- a/larpandoracontent/LArShowerRefinement/LArProtoShower.h
+++ b/larpandoracontent/LArShowerRefinement/LArProtoShower.h
@@ -57,13 +57,16 @@ private:
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline ShowerCore::ShowerCore(const pandora::CartesianVector &startPosition, const pandora::CartesianVector &startDirection) :
-    m_startPosition(startPosition), m_startDirection(startDirection)
+    m_startPosition(startPosition),
+    m_startDirection(startDirection)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline ShowerCore::ShowerCore() : m_startPosition(0.f, 0.f, 0.f), m_startDirection(0.f, 0.f, 0.f)
+inline ShowerCore::ShowerCore() :
+    m_startPosition(0.f, 0.f, 0.f),
+    m_startDirection(0.f, 0.f, 0.f)
 {
 }
 
@@ -127,13 +130,16 @@ typedef std::vector<ConnectionPathway> ConnectionPathwayVector;
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline ConnectionPathway::ConnectionPathway(const pandora::CartesianVector &startPosition, const pandora::CartesianVector &startDirection) :
-    m_startPosition(startPosition), m_startDirection(startDirection)
+    m_startPosition(startPosition),
+    m_startDirection(startDirection)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline ConnectionPathway::ConnectionPathway() : m_startPosition(0.f, 0.f, 0.f), m_startDirection(0.f, 0.f, 0.f)
+inline ConnectionPathway::ConnectionPathway() :
+    m_startPosition(0.f, 0.f, 0.f),
+    m_startDirection(0.f, 0.f, 0.f)
 {
 }
 
@@ -446,7 +452,10 @@ typedef std::vector<ProtoShowerMatch> ProtoShowerMatchVector;
 
 inline ProtoShowerMatch::ProtoShowerMatch(
     const ProtoShower &protoShowerU, const ProtoShower &protoShowerV, const ProtoShower &protoShowerW, const Consistency consistencyType) :
-    m_protoShowerU(protoShowerU), m_protoShowerV(protoShowerV), m_protoShowerW(protoShowerW), m_consistencyType(consistencyType)
+    m_protoShowerU(protoShowerU),
+    m_protoShowerV(protoShowerV),
+    m_protoShowerW(protoShowerW),
+    m_consistencyType(consistencyType)
 {
 }
 

--- a/larpandoracontent/LArShowerRefinement/PeakDirectionFinderTool.cc
+++ b/larpandoracontent/LArShowerRefinement/PeakDirectionFinderTool.cc
@@ -20,7 +20,10 @@ namespace lar_content
 {
 
 PeakDirectionFinderTool::PeakDirectionFinderTool() :
-    m_pathwaySearchRegion(10.f), m_theta0XZBinSize(0.005f), m_smoothingWindow(1), m_ambiguousParticleMode(false)
+    m_pathwaySearchRegion(10.f),
+    m_theta0XZBinSize(0.005f),
+    m_smoothingWindow(1),
+    m_ambiguousParticleMode(false)
 {
 }
 
@@ -185,8 +188,8 @@ void PeakDirectionFinderTool::SmoothAngularDecompositionMap(AngularDecomposition
         {
             const int contributingBin = currentBin + binOffset;
             total += (angularDecompositionMapTemp.find(contributingBin) == angularDecompositionMapTemp.end())
-                         ? 0.f
-                         : angularDecompositionMapTemp.at(contributingBin);
+                ? 0.f
+                : angularDecompositionMapTemp.at(contributingBin);
         }
 
         angularDecompositionMap[currentBin] = total / static_cast<float>((2.0 * m_smoothingWindow) + 1);

--- a/larpandoracontent/LArShowerRefinement/ProtoShowerMatchingTool.cc
+++ b/larpandoracontent/LArShowerRefinement/ProtoShowerMatchingTool.cc
@@ -23,7 +23,10 @@ namespace lar_content
 {
 
 ProtoShowerMatchingTool::ProtoShowerMatchingTool() :
-    m_spineSlidingFitWindow(20), m_maxXSeparation(5.f), m_maxSeparation(5.f), m_maxAngularDeviation(5.f)
+    m_spineSlidingFitWindow(20),
+    m_maxXSeparation(5.f),
+    m_maxSeparation(5.f),
+    m_maxAngularDeviation(5.f)
 {
 }
 

--- a/larpandoracontent/LArShowerRefinement/ShowerSpineFinderTool.cc
+++ b/larpandoracontent/LArShowerRefinement/ShowerSpineFinderTool.cc
@@ -117,9 +117,9 @@ void ShowerSpineFinderTool::FindShowerSpine(const CaloHitList *const pViewHitLis
 
             const TwoDSlidingFitResult extrapolatedFit(&runningFitPositionVector, m_localSlidingFitWindow, slidingFitPitch);
 
-            extrapolatedStartPosition = count == 1        ? extrapolatedEndPosition
-                                        : isEndDownstream ? extrapolatedFit.GetGlobalMaxLayerPosition()
-                                                          : extrapolatedFit.GetGlobalMinLayerPosition();
+            extrapolatedStartPosition = count == 1 ? extrapolatedEndPosition
+                : isEndDownstream                  ? extrapolatedFit.GetGlobalMaxLayerPosition()
+                                                   : extrapolatedFit.GetGlobalMinLayerPosition();
             extrapolatedDirection =
                 isEndDownstream ? extrapolatedFit.GetGlobalMaxLayerDirection() : extrapolatedFit.GetGlobalMinLayerDirection() * (-1.f);
             extrapolatedEndPosition = extrapolatedStartPosition + (extrapolatedDirection * m_growingFitSegmentLength);
@@ -132,9 +132,9 @@ void ShowerSpineFinderTool::FindShowerSpine(const CaloHitList *const pViewHitLis
             {
                 const TwoDSlidingFitResult microExtrapolatedFit(&runningFitPositionVector, m_highResolutionSlidingFitWindow, slidingFitPitch);
 
-                extrapolatedStartPosition = count == 1        ? extrapolatedStartPosition
-                                            : isEndDownstream ? microExtrapolatedFit.GetGlobalMaxLayerPosition()
-                                                              : microExtrapolatedFit.GetGlobalMinLayerPosition();
+                extrapolatedStartPosition = count == 1 ? extrapolatedStartPosition
+                    : isEndDownstream                  ? microExtrapolatedFit.GetGlobalMaxLayerPosition()
+                                                       : microExtrapolatedFit.GetGlobalMinLayerPosition();
                 extrapolatedDirection = isEndDownstream ? microExtrapolatedFit.GetGlobalMaxLayerDirection()
                                                         : microExtrapolatedFit.GetGlobalMinLayerDirection() * (-1.f);
                 extrapolatedEndPosition = extrapolatedStartPosition + (extrapolatedDirection * m_growingFitSegmentLength);

--- a/larpandoracontent/LArShowerRefinement/ShowerStartFinderTool.cc
+++ b/larpandoracontent/LArShowerRefinement/ShowerStartFinderTool.cc
@@ -114,7 +114,7 @@ void ShowerStartFinderTool::ObtainLongitudinalDecomposition(const TwoDSlidingFit
         spineTwoDSlidingFit.GetGlobalPosition(layerFitResultMap.at(higherLayer).GetL(), layerFitResultMap.at(higherLayer).GetFitT(), higherLayerPosition);
 
         const float layerLength = std::next(iter) == layerToHitMap.end() ? 0.f
-                                  : iter == layerToHitMap.begin()        ? 0.f
+            : iter == layerToHitMap.begin()                              ? 0.f
                                                                          : (middleLayerPosition - lowerLayerPosition).GetMagnitude();
 
         for (const CaloHit *const pCaloHit : iter->second)

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/AmbiguousDeltaRayTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/AmbiguousDeltaRayTool.cc
@@ -15,7 +15,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-AmbiguousDeltaRayTool::AmbiguousDeltaRayTool() : m_maxGoodMatchReducedChiSquared(1.f)
+AmbiguousDeltaRayTool::AmbiguousDeltaRayTool() :
+    m_maxGoodMatchReducedChiSquared(1.f)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayBaseMatchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayBaseMatchingAlgorithm.cc
@@ -152,18 +152,18 @@ void CosmicRayBaseMatchingAlgorithm::MatchThreeViews(const ClusterAssociationMap
                 if (!this->CheckMatchedClusters3D(pCluster1, pCluster2, pCluster3))
                     continue;
 
-                const Cluster *const pClusterU((TPC_VIEW_U == hitType1)   ? pCluster1
-                                               : (TPC_VIEW_U == hitType2) ? pCluster2
-                                               : (TPC_VIEW_U == hitType3) ? pCluster3
-                                                                          : NULL);
-                const Cluster *const pClusterV((TPC_VIEW_V == hitType1)   ? pCluster1
-                                               : (TPC_VIEW_V == hitType2) ? pCluster2
-                                               : (TPC_VIEW_V == hitType3) ? pCluster3
-                                                                          : NULL);
-                const Cluster *const pClusterW((TPC_VIEW_W == hitType1)   ? pCluster1
-                                               : (TPC_VIEW_W == hitType2) ? pCluster2
-                                               : (TPC_VIEW_W == hitType3) ? pCluster3
-                                                                          : NULL);
+                const Cluster *const pClusterU((TPC_VIEW_U == hitType1) ? pCluster1
+                        : (TPC_VIEW_U == hitType2)                      ? pCluster2
+                        : (TPC_VIEW_U == hitType3)                      ? pCluster3
+                                                                        : NULL);
+                const Cluster *const pClusterV((TPC_VIEW_V == hitType1) ? pCluster1
+                        : (TPC_VIEW_V == hitType2)                      ? pCluster2
+                        : (TPC_VIEW_V == hitType3)                      ? pCluster3
+                                                                        : NULL);
+                const Cluster *const pClusterW((TPC_VIEW_W == hitType1) ? pCluster1
+                        : (TPC_VIEW_W == hitType2)                      ? pCluster2
+                        : (TPC_VIEW_W == hitType3)                      ? pCluster3
+                                                                        : NULL);
 
                 candidateParticles.push_back(Particle(pClusterU, pClusterV, pClusterW));
             }
@@ -290,7 +290,9 @@ void CosmicRayBaseMatchingAlgorithm::BuildParticles(const ParticleList &particle
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 CosmicRayBaseMatchingAlgorithm::Particle::Particle(const Cluster *const pClusterU, const Cluster *const pClusterV, const Cluster *const pClusterW) :
-    m_pClusterU(pClusterU), m_pClusterV(pClusterV), m_pClusterW(pClusterW)
+    m_pClusterU(pClusterU),
+    m_pClusterV(pClusterV),
+    m_pClusterW(pClusterW)
 {
     if (NULL == m_pClusterU && NULL == m_pClusterV && NULL == m_pClusterW)
         throw StatusCodeException(STATUS_CODE_FAILURE);

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayRemovalTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayRemovalTool.cc
@@ -21,7 +21,11 @@ namespace lar_content
 {
 
 CosmicRayRemovalTool::CosmicRayRemovalTool() :
-    m_slidingFitWindow(10000), m_minContaminationLength(3.f), m_maxDistanceToHit(1.f), m_minRemnantClusterSize(3), m_maxDistanceToTrack(2.f)
+    m_slidingFitWindow(10000),
+    m_minContaminationLength(3.f),
+    m_maxDistanceToHit(1.f),
+    m_minRemnantClusterSize(3),
+    m_maxDistanceToTrack(2.f)
 {
 }
 
@@ -277,8 +281,8 @@ void CosmicRayRemovalTool::CollectHitsFromDeltaRay(const CartesianVector &positi
                 continue;
 
             const float distanceToCollectedHits(collectedHits.empty()
-                                                    ? std::numeric_limits<float>::max()
-                                                    : LArClusterHelper::GetClosestDistance(pCaloHit->GetPositionVector(), collectedHits));
+                    ? std::numeric_limits<float>::max()
+                    : LArClusterHelper::GetClosestDistance(pCaloHit->GetPositionVector(), collectedHits));
             const float distanceToMuonHits(muonDirection.GetCrossProduct(pCaloHit->GetPositionVector() - positionOnMuon).GetMagnitude());
 
             if ((distanceToMuonHits < minDistanceFromMuon) || (demandCloserToCollected && (distanceToCollectedHits > distanceToMuonHits)))

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayShowerMatchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayShowerMatchingAlgorithm.cc
@@ -19,7 +19,10 @@ namespace lar_content
 {
 
 CosmicRayShowerMatchingAlgorithm::CosmicRayShowerMatchingAlgorithm() :
-    m_minCaloHitsPerCluster(10), m_minXOverlap(1.f), m_minXOverlapFraction(0.5f), m_pseudoChi2Cut(5.f)
+    m_minCaloHitsPerCluster(10),
+    m_minXOverlap(1.f),
+    m_minXOverlapFraction(0.5f),
+    m_pseudoChi2Cut(5.f)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayTrackMatchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayTrackMatchingAlgorithm.cc
@@ -19,7 +19,11 @@ namespace lar_content
 {
 
 CosmicRayTrackMatchingAlgorithm::CosmicRayTrackMatchingAlgorithm() :
-    m_clusterMinLength(10.f), m_vtxXOverlap(3.f), m_minXOverlap(3.f), m_minXOverlapFraction(0.8f), m_maxDisplacement(10.f)
+    m_clusterMinLength(10.f),
+    m_vtxXOverlap(3.f),
+    m_minXOverlap(3.f),
+    m_minXOverlapFraction(0.8f),
+    m_maxDisplacement(10.f)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayTrackRecoveryAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayTrackRecoveryAlgorithm.cc
@@ -20,7 +20,11 @@ namespace lar_content
 {
 
 CosmicRayTrackRecoveryAlgorithm::CosmicRayTrackRecoveryAlgorithm() :
-    m_clusterMinLength(10.f), m_clusterMinSpanZ(2.f), m_clusterMinOverlapX(6.f), m_clusterMaxDeltaX(3.f), m_clusterMinHits(3)
+    m_clusterMinLength(10.f),
+    m_clusterMinSpanZ(2.f),
+    m_clusterMinOverlapX(6.f),
+    m_clusterMaxDeltaX(3.f),
+    m_clusterMinHits(3)
 {
 }
 
@@ -361,31 +365,34 @@ void CosmicRayTrackRecoveryAlgorithm::MatchThreeViews(const ClusterVector &clust
                 const ClusterAssociationMap::const_iterator iter313 = matchedClusters31.find(pCluster3);
                 const ClusterList matchedClusters31_pCluster3(iter313 != matchedClusters31.end() ? iter313->second : ClusterList());
 
-                const bool match12(
-                    (matchedClusters12_pCluster1.size() + matchedClusters12_pCluster2.size() > 0) &&
-                    ((matchedClusters12_pCluster1.size() == 1 && std::find(matchedClusters12_pCluster1.begin(), matchedClusters12_pCluster1.end(),
-                                                                     pCluster2) != matchedClusters12_pCluster1.end()) ||
+                const bool match12((matchedClusters12_pCluster1.size() + matchedClusters12_pCluster2.size() > 0) &&
+                    ((matchedClusters12_pCluster1.size() == 1 &&
+                         std::find(matchedClusters12_pCluster1.begin(), matchedClusters12_pCluster1.end(), pCluster2) !=
+                             matchedClusters12_pCluster1.end()) ||
                         (matchedClusters12_pCluster1.size() == 0)) &&
-                    ((matchedClusters12_pCluster2.size() == 1 && std::find(matchedClusters12_pCluster2.begin(), matchedClusters12_pCluster2.end(),
-                                                                     pCluster1) != matchedClusters12_pCluster2.end()) ||
+                    ((matchedClusters12_pCluster2.size() == 1 &&
+                         std::find(matchedClusters12_pCluster2.begin(), matchedClusters12_pCluster2.end(), pCluster1) !=
+                             matchedClusters12_pCluster2.end()) ||
                         (matchedClusters12_pCluster2.size() == 0)));
 
-                const bool match23(
-                    (matchedClusters23_pCluster2.size() + matchedClusters23_pCluster3.size() > 0) &&
-                    ((matchedClusters23_pCluster2.size() == 1 && std::find(matchedClusters23_pCluster2.begin(), matchedClusters23_pCluster2.end(),
-                                                                     pCluster3) != matchedClusters23_pCluster2.end()) ||
+                const bool match23((matchedClusters23_pCluster2.size() + matchedClusters23_pCluster3.size() > 0) &&
+                    ((matchedClusters23_pCluster2.size() == 1 &&
+                         std::find(matchedClusters23_pCluster2.begin(), matchedClusters23_pCluster2.end(), pCluster3) !=
+                             matchedClusters23_pCluster2.end()) ||
                         (matchedClusters23_pCluster2.size() == 0)) &&
-                    ((matchedClusters23_pCluster3.size() == 1 && std::find(matchedClusters23_pCluster3.begin(), matchedClusters23_pCluster3.end(),
-                                                                     pCluster2) != matchedClusters23_pCluster3.end()) ||
+                    ((matchedClusters23_pCluster3.size() == 1 &&
+                         std::find(matchedClusters23_pCluster3.begin(), matchedClusters23_pCluster3.end(), pCluster2) !=
+                             matchedClusters23_pCluster3.end()) ||
                         (matchedClusters23_pCluster3.size() == 0)));
 
-                const bool match31(
-                    (matchedClusters31_pCluster3.size() + matchedClusters31_pCluster1.size() > 0) &&
-                    ((matchedClusters31_pCluster3.size() == 1 && std::find(matchedClusters31_pCluster3.begin(), matchedClusters31_pCluster3.end(),
-                                                                     pCluster1) != matchedClusters31_pCluster3.end()) ||
+                const bool match31((matchedClusters31_pCluster3.size() + matchedClusters31_pCluster1.size() > 0) &&
+                    ((matchedClusters31_pCluster3.size() == 1 &&
+                         std::find(matchedClusters31_pCluster3.begin(), matchedClusters31_pCluster3.end(), pCluster1) !=
+                             matchedClusters31_pCluster3.end()) ||
                         (matchedClusters31_pCluster3.size() == 0)) &&
-                    ((matchedClusters31_pCluster1.size() == 1 && std::find(matchedClusters31_pCluster1.begin(), matchedClusters31_pCluster1.end(),
-                                                                     pCluster3) != matchedClusters31_pCluster1.end()) ||
+                    ((matchedClusters31_pCluster1.size() == 1 &&
+                         std::find(matchedClusters31_pCluster1.begin(), matchedClusters31_pCluster1.end(), pCluster3) !=
+                             matchedClusters31_pCluster1.end()) ||
                         (matchedClusters31_pCluster1.size() == 0)));
 
                 if (match12 && match23 && match31)
@@ -420,15 +427,15 @@ void CosmicRayTrackRecoveryAlgorithm::MatchTwoViews(const ClusterVector &cluster
         const ClusterVector &clusterVector2((0 == iView) ? clusterVectorV : (1 == iView) ? clusterVectorW : clusterVectorU);
         const ClusterVector &clusterVector3((0 == iView) ? clusterVectorW : (1 == iView) ? clusterVectorU : clusterVectorV);
 
-        const ClusterAssociationMap &matchedClusters12(((0 == iView)   ? matchedClustersUV
-                                                        : (1 == iView) ? matchedClustersVW
-                                                                       : matchedClustersWU));
-        const ClusterAssociationMap &matchedClusters23(((0 == iView)   ? matchedClustersVW
-                                                        : (1 == iView) ? matchedClustersWU
-                                                                       : matchedClustersUV));
-        const ClusterAssociationMap &matchedClusters31(((0 == iView)   ? matchedClustersWU
-                                                        : (1 == iView) ? matchedClustersUV
-                                                                       : matchedClustersVW));
+        const ClusterAssociationMap &matchedClusters12(((0 == iView) ? matchedClustersUV
+                : (1 == iView)                                       ? matchedClustersVW
+                                                                     : matchedClustersWU));
+        const ClusterAssociationMap &matchedClusters23(((0 == iView) ? matchedClustersVW
+                : (1 == iView)                                       ? matchedClustersWU
+                                                                     : matchedClustersUV));
+        const ClusterAssociationMap &matchedClusters31(((0 == iView) ? matchedClustersWU
+                : (1 == iView)                                       ? matchedClustersUV
+                                                                     : matchedClustersVW));
 
         for (ClusterVector::const_iterator iter1 = clusterVector1.begin(), iterEnd1 = clusterVector1.end(); iter1 != iterEnd1; ++iter1)
         {
@@ -456,11 +463,12 @@ void CosmicRayTrackRecoveryAlgorithm::MatchTwoViews(const ClusterVector &cluster
                 const ClusterAssociationMap::const_iterator iter232 = matchedClusters23.find(pCluster2);
                 const ClusterList matchedClusters23_pCluster2(iter232 != matchedClusters23.end() ? iter232->second : ClusterList());
 
-                const bool match12(
-                    (matchedClusters12_pCluster1.size() == 1 && std::find(matchedClusters12_pCluster1.begin(), matchedClusters12_pCluster1.end(),
-                                                                    pCluster2) != matchedClusters12_pCluster1.end()) &&
-                    (matchedClusters12_pCluster2.size() == 1 && std::find(matchedClusters12_pCluster2.begin(), matchedClusters12_pCluster2.end(),
-                                                                    pCluster1) != matchedClusters12_pCluster2.end()) &&
+                const bool match12((matchedClusters12_pCluster1.size() == 1 &&
+                                       std::find(matchedClusters12_pCluster1.begin(), matchedClusters12_pCluster1.end(), pCluster2) !=
+                                           matchedClusters12_pCluster1.end()) &&
+                    (matchedClusters12_pCluster2.size() == 1 &&
+                        std::find(matchedClusters12_pCluster2.begin(), matchedClusters12_pCluster2.end(), pCluster1) !=
+                            matchedClusters12_pCluster2.end()) &&
                     (matchedClusters23_pCluster2.size() == 0 && matchedClusters31_pCluster1.size() == 0));
 
                 if (!match12)
@@ -484,14 +492,14 @@ void CosmicRayTrackRecoveryAlgorithm::MatchTwoViews(const ClusterVector &cluster
                     const ClusterList matchedClusters31_pCluster3(iter313 != matchedClusters31.end() ? iter313->second : ClusterList());
 
                     const bool match3((matchedClusters31_pCluster3.size() + matchedClusters23_pCluster3.size() > 0) &&
-                                      ((matchedClusters31_pCluster3.size() == 1 &&
-                                           std::find(matchedClusters31_pCluster3.begin(), matchedClusters31_pCluster3.end(), pCluster1) !=
-                                               matchedClusters31_pCluster3.end()) ||
-                                          (matchedClusters31_pCluster3.size() == 0)) &&
-                                      ((matchedClusters23_pCluster3.size() == 1 &&
-                                           std::find(matchedClusters23_pCluster3.begin(), matchedClusters23_pCluster3.end(), pCluster2) !=
-                                               matchedClusters23_pCluster3.end()) ||
-                                          (matchedClusters23_pCluster3.size() == 0)));
+                        ((matchedClusters31_pCluster3.size() == 1 &&
+                             std::find(matchedClusters31_pCluster3.begin(), matchedClusters31_pCluster3.end(), pCluster1) !=
+                                 matchedClusters31_pCluster3.end()) ||
+                            (matchedClusters31_pCluster3.size() == 0)) &&
+                        ((matchedClusters23_pCluster3.size() == 1 &&
+                             std::find(matchedClusters23_pCluster3.begin(), matchedClusters23_pCluster3.end(), pCluster2) !=
+                                 matchedClusters23_pCluster3.end()) ||
+                            (matchedClusters23_pCluster3.size() == 0)));
 
                     if (match3)
                         newParticle.m_clusterList.push_back(pCluster3);
@@ -522,15 +530,15 @@ void CosmicRayTrackRecoveryAlgorithm::MatchOneView(const ClusterVector &clusterV
         const ClusterVector &clusterVector2((0 == iView) ? clusterVectorV : (1 == iView) ? clusterVectorW : clusterVectorU);
         const ClusterVector &clusterVector3((0 == iView) ? clusterVectorW : (1 == iView) ? clusterVectorU : clusterVectorV);
 
-        const ClusterAssociationMap &matchedClusters12(((0 == iView)   ? matchedClustersUV
-                                                        : (1 == iView) ? matchedClustersVW
-                                                                       : matchedClustersWU));
-        const ClusterAssociationMap &matchedClusters23(((0 == iView)   ? matchedClustersVW
-                                                        : (1 == iView) ? matchedClustersWU
-                                                                       : matchedClustersUV));
-        const ClusterAssociationMap &matchedClusters31(((0 == iView)   ? matchedClustersWU
-                                                        : (1 == iView) ? matchedClustersUV
-                                                                       : matchedClustersVW));
+        const ClusterAssociationMap &matchedClusters12(((0 == iView) ? matchedClustersUV
+                : (1 == iView)                                       ? matchedClustersVW
+                                                                     : matchedClustersWU));
+        const ClusterAssociationMap &matchedClusters23(((0 == iView) ? matchedClustersVW
+                : (1 == iView)                                       ? matchedClustersWU
+                                                                     : matchedClustersUV));
+        const ClusterAssociationMap &matchedClusters31(((0 == iView) ? matchedClustersWU
+                : (1 == iView)                                       ? matchedClustersUV
+                                                                     : matchedClustersVW));
 
         for (ClusterVector::const_iterator iter1 = clusterVector1.begin(), iterEnd1 = clusterVector1.end(); iter1 != iterEnd1; ++iter1)
         {
@@ -707,9 +715,9 @@ void CosmicRayTrackRecoveryAlgorithm::MergeClusters(const ClusterList &inputClus
     for (unsigned int iView = 0; iView < 3; ++iView)
     {
         const ClusterList clusterList((0 == iView) ? clusterListU : (1 == iView) ? clusterListV : clusterListW);
-        const std::string inputClusterListName((0 == iView)   ? m_inputClusterListNameU
-                                               : (1 == iView) ? m_inputClusterListNameV
-                                                              : m_inputClusterListNameW);
+        const std::string inputClusterListName((0 == iView) ? m_inputClusterListNameU
+                : (1 == iView)                              ? m_inputClusterListNameV
+                                                            : m_inputClusterListNameW);
 
         if (clusterList.empty())
             continue;

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayVertexBuildingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayVertexBuildingAlgorithm.cc
@@ -20,7 +20,10 @@ namespace lar_content
 {
 
 CosmicRayVertexBuildingAlgorithm::CosmicRayVertexBuildingAlgorithm() :
-    m_useParentShowerVertex(false), m_isDualPhase(false), m_halfWindowLayers(30), m_maxVertexDisplacementFromTrack(1.f)
+    m_useParentShowerVertex(false),
+    m_isDualPhase(false),
+    m_halfWindowLayers(30),
+    m_maxVertexDisplacementFromTrack(1.f)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/DeltaRayIdentificationAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/DeltaRayIdentificationAlgorithm.cc
@@ -19,7 +19,9 @@ namespace lar_content
 {
 
 DeltaRayIdentificationAlgorithm::DeltaRayIdentificationAlgorithm() :
-    m_distanceForMatching(3.f), m_minParentLengthSquared(10.f * 10.f), m_maxDaughterLengthSquared(175.f * 175.f)
+    m_distanceForMatching(3.f),
+    m_minParentLengthSquared(10.f * 10.f),
+    m_maxDaughterLengthSquared(175.f * 175.f)
 {
 }
 
@@ -160,8 +162,8 @@ bool DeltaRayIdentificationAlgorithm::IsAssociated(
 
     const float transitionLengthSquared(125.f);
     const float displacementCut((daughterLengthSquared > transitionLengthSquared)
-                                    ? m_distanceForMatching
-                                    : m_distanceForMatching * (2.f - daughterLengthSquared / transitionLengthSquared));
+            ? m_distanceForMatching
+            : m_distanceForMatching * (2.f - daughterLengthSquared / transitionLengthSquared));
 
     try
     {

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/DeltaRayMatchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/DeltaRayMatchingAlgorithm.cc
@@ -22,7 +22,11 @@ namespace lar_content
 {
 
 DeltaRayMatchingAlgorithm::DeltaRayMatchingAlgorithm() :
-    m_minCaloHitsPerCluster(3), m_xOverlapWindow(1.f), m_distanceForMatching(5.f), m_pseudoChi2Cut(3.f), m_searchRegion1D(5.f)
+    m_minCaloHitsPerCluster(3),
+    m_xOverlapWindow(1.f),
+    m_distanceForMatching(5.f),
+    m_pseudoChi2Cut(3.f),
+    m_searchRegion1D(5.f)
 {
 }
 
@@ -639,9 +643,9 @@ float DeltaRayMatchingAlgorithm::GetDistanceSquaredToPfo(const Cluster *const pC
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
     ClusterList comparisonList;
-    const ClusterToClustersMap &nearbyClusters((TPC_VIEW_U == hitType)   ? m_nearbyClustersU
-                                               : (TPC_VIEW_V == hitType) ? m_nearbyClustersV
-                                                                         : m_nearbyClustersW);
+    const ClusterToClustersMap &nearbyClusters((TPC_VIEW_U == hitType) ? m_nearbyClustersU
+            : (TPC_VIEW_V == hitType)                                  ? m_nearbyClustersV
+                                                                       : m_nearbyClustersW);
 
     if (!nearbyClusters.count(pCluster))
         return std::numeric_limits<float>::max();
@@ -700,9 +704,9 @@ void DeltaRayMatchingAlgorithm::AddToDaughterPfo(const ClusterList &clusterList,
     for (const Cluster *const pDaughterCluster : clusterList)
     {
         const HitType hitType(LArClusterHelper::GetClusterHitType(pDaughterCluster));
-        const std::string clusterListName((TPC_VIEW_U == hitType)   ? m_inputClusterListNameU
-                                          : (TPC_VIEW_V == hitType) ? m_inputClusterListNameV
-                                                                    : m_inputClusterListNameW);
+        const std::string clusterListName((TPC_VIEW_U == hitType) ? m_inputClusterListNameU
+                : (TPC_VIEW_V == hitType)                         ? m_inputClusterListNameV
+                                                                  : m_inputClusterListNameW);
 
         ClusterList pfoClusters;
         LArPfoHelper::GetClusters(pParentPfo, hitType, pfoClusters);
@@ -722,24 +726,27 @@ void DeltaRayMatchingAlgorithm::AddToDaughterPfo(const ClusterList &clusterList,
 
 DeltaRayMatchingAlgorithm::Particle::Particle(
     const Cluster *const pCluster1, const Cluster *const pCluster2, const Cluster *const pCluster3, const ParticleFlowObject *const pPfo) :
-    m_pClusterU(NULL), m_pClusterV(NULL), m_pClusterW(NULL), m_pParentPfo(NULL)
+    m_pClusterU(NULL),
+    m_pClusterV(NULL),
+    m_pClusterW(NULL),
+    m_pParentPfo(NULL)
 {
     const HitType hitType1(NULL != pCluster1 ? LArClusterHelper::GetClusterHitType(pCluster1) : HIT_CUSTOM);
     const HitType hitType2(NULL != pCluster2 ? LArClusterHelper::GetClusterHitType(pCluster2) : HIT_CUSTOM);
     const HitType hitType3(NULL != pCluster3 ? LArClusterHelper::GetClusterHitType(pCluster3) : HIT_CUSTOM);
 
-    m_pClusterU = ((TPC_VIEW_U == hitType1)   ? pCluster1
-                   : (TPC_VIEW_U == hitType2) ? pCluster2
-                   : (TPC_VIEW_U == hitType3) ? pCluster3
-                                              : NULL);
-    m_pClusterV = ((TPC_VIEW_V == hitType1)   ? pCluster1
-                   : (TPC_VIEW_V == hitType2) ? pCluster2
-                   : (TPC_VIEW_V == hitType3) ? pCluster3
-                                              : NULL);
-    m_pClusterW = ((TPC_VIEW_W == hitType1)   ? pCluster1
-                   : (TPC_VIEW_W == hitType2) ? pCluster2
-                   : (TPC_VIEW_W == hitType3) ? pCluster3
-                                              : NULL);
+    m_pClusterU = ((TPC_VIEW_U == hitType1) ? pCluster1
+            : (TPC_VIEW_U == hitType2)      ? pCluster2
+            : (TPC_VIEW_U == hitType3)      ? pCluster3
+                                            : NULL);
+    m_pClusterV = ((TPC_VIEW_V == hitType1) ? pCluster1
+            : (TPC_VIEW_V == hitType2)      ? pCluster2
+            : (TPC_VIEW_V == hitType3)      ? pCluster3
+                                            : NULL);
+    m_pClusterW = ((TPC_VIEW_W == hitType1) ? pCluster1
+            : (TPC_VIEW_W == hitType2)      ? pCluster2
+            : (TPC_VIEW_W == hitType3)      ? pCluster3
+                                            : NULL);
     m_pParentPfo = pPfo;
 
     if (NULL == m_pClusterU && NULL == m_pClusterV && NULL == m_pClusterW)

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/DeltaRayMatchingContainers.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/DeltaRayMatchingContainers.cc
@@ -20,7 +20,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-DeltaRayMatchingContainers::DeltaRayMatchingContainers() : m_searchRegion1D(3.f)
+DeltaRayMatchingContainers::DeltaRayMatchingContainers() :
+    m_searchRegion1D(3.f)
 {
 }
 
@@ -53,9 +54,9 @@ void DeltaRayMatchingContainers::FillHitToClusterMap(const ClusterList &inputClu
 void DeltaRayMatchingContainers::AddToClusterMap(const Cluster *const pCluster)
 {
     const HitType hitType(LArClusterHelper::GetClusterHitType(pCluster));
-    HitToClusterMap &hitToClusterMap((hitType == TPC_VIEW_U)   ? m_hitToClusterMapU
-                                     : (hitType == TPC_VIEW_V) ? m_hitToClusterMapV
-                                                               : m_hitToClusterMapW);
+    HitToClusterMap &hitToClusterMap((hitType == TPC_VIEW_U) ? m_hitToClusterMapU
+            : (hitType == TPC_VIEW_V)                        ? m_hitToClusterMapV
+                                                             : m_hitToClusterMapW);
 
     CaloHitList caloHitList;
     pCluster->GetOrderedCaloHitList().FillCaloHitList(caloHitList);
@@ -83,9 +84,9 @@ void DeltaRayMatchingContainers::FillClusterProximityMap(const ClusterList &inpu
 
 void DeltaRayMatchingContainers::BuildKDTree(const HitType hitType)
 {
-    const HitToClusterMap &hitToClusterMap((hitType == TPC_VIEW_U)   ? m_hitToClusterMapU
-                                           : (hitType == TPC_VIEW_V) ? m_hitToClusterMapV
-                                                                     : m_hitToClusterMapW);
+    const HitToClusterMap &hitToClusterMap((hitType == TPC_VIEW_U) ? m_hitToClusterMapU
+            : (hitType == TPC_VIEW_V)                              ? m_hitToClusterMapV
+                                                                   : m_hitToClusterMapW);
     HitKDTree2D &kdTree((hitType == TPC_VIEW_U) ? m_kdTreeU : (hitType == TPC_VIEW_V) ? m_kdTreeV : m_kdTreeW);
 
     CaloHitList allCaloHits;
@@ -104,13 +105,13 @@ void DeltaRayMatchingContainers::BuildKDTree(const HitType hitType)
 void DeltaRayMatchingContainers::AddToClusterProximityMap(const Cluster *const pCluster)
 {
     const HitType hitType(LArClusterHelper::GetClusterHitType(pCluster));
-    const HitToClusterMap &hitToClusterMap((hitType == TPC_VIEW_U)   ? m_hitToClusterMapU
-                                           : (hitType == TPC_VIEW_V) ? m_hitToClusterMapV
-                                                                     : m_hitToClusterMapW);
+    const HitToClusterMap &hitToClusterMap((hitType == TPC_VIEW_U) ? m_hitToClusterMapU
+            : (hitType == TPC_VIEW_V)                              ? m_hitToClusterMapV
+                                                                   : m_hitToClusterMapW);
     HitKDTree2D &kdTree((hitType == TPC_VIEW_U) ? m_kdTreeU : (hitType == TPC_VIEW_V) ? m_kdTreeV : m_kdTreeW);
-    ClusterProximityMap &clusterProximityMap((hitType == TPC_VIEW_U)   ? m_clusterProximityMapU
-                                             : (hitType == TPC_VIEW_V) ? m_clusterProximityMapV
-                                                                       : m_clusterProximityMapW);
+    ClusterProximityMap &clusterProximityMap((hitType == TPC_VIEW_U) ? m_clusterProximityMapU
+            : (hitType == TPC_VIEW_V)                                ? m_clusterProximityMapV
+                                                                     : m_clusterProximityMapW);
 
     CaloHitList caloHitList;
     pCluster->GetOrderedCaloHitList().FillCaloHitList(caloHitList);
@@ -159,9 +160,9 @@ void DeltaRayMatchingContainers::AddClustersToPfoMaps(const ParticleFlowObject *
         ClusterList pfoClusters;
         LArPfoHelper::GetClusters(pPfo, hitType, pfoClusters);
 
-        ClusterToPfoMap &clusterToPfoMap((hitType == TPC_VIEW_U)   ? m_clusterToPfoMapU
-                                         : (hitType == TPC_VIEW_V) ? m_clusterToPfoMapV
-                                                                   : m_clusterToPfoMapW);
+        ClusterToPfoMap &clusterToPfoMap((hitType == TPC_VIEW_U) ? m_clusterToPfoMapU
+                : (hitType == TPC_VIEW_V)                        ? m_clusterToPfoMapV
+                                                                 : m_clusterToPfoMapW);
 
         for (const Cluster *const pCluster : pfoClusters)
         {
@@ -197,15 +198,15 @@ void DeltaRayMatchingContainers::AddClustersToContainers(const ClusterVector &ne
 void DeltaRayMatchingContainers::RemoveClusterFromContainers(const Cluster *const pDeletedCluster)
 {
     const HitType hitType(LArClusterHelper::GetClusterHitType(pDeletedCluster));
-    HitToClusterMap &hitToClusterMap((hitType == TPC_VIEW_U)   ? m_hitToClusterMapU
-                                     : (hitType == TPC_VIEW_V) ? m_hitToClusterMapV
-                                                               : m_hitToClusterMapW);
-    ClusterProximityMap &clusterProximityMap((hitType == TPC_VIEW_U)   ? m_clusterProximityMapU
-                                             : (hitType == TPC_VIEW_V) ? m_clusterProximityMapV
-                                                                       : m_clusterProximityMapW);
-    ClusterToPfoMap &clusterToPfoMap((hitType == TPC_VIEW_U)   ? m_clusterToPfoMapU
-                                     : (hitType == TPC_VIEW_V) ? m_clusterToPfoMapV
-                                                               : m_clusterToPfoMapW);
+    HitToClusterMap &hitToClusterMap((hitType == TPC_VIEW_U) ? m_hitToClusterMapU
+            : (hitType == TPC_VIEW_V)                        ? m_hitToClusterMapV
+                                                             : m_hitToClusterMapW);
+    ClusterProximityMap &clusterProximityMap((hitType == TPC_VIEW_U) ? m_clusterProximityMapU
+            : (hitType == TPC_VIEW_V)                                ? m_clusterProximityMapV
+                                                                     : m_clusterProximityMapW);
+    ClusterToPfoMap &clusterToPfoMap((hitType == TPC_VIEW_U) ? m_clusterToPfoMapU
+            : (hitType == TPC_VIEW_V)                        ? m_clusterToPfoMapV
+                                                             : m_clusterToPfoMapW);
 
     CaloHitList caloHitList;
     pDeletedCluster->GetOrderedCaloHitList().FillCaloHitList(caloHitList);

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/DeltaRayMergeTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/DeltaRayMergeTool.cc
@@ -20,7 +20,10 @@ namespace lar_content
 {
 
 DeltaRayMergeTool::DeltaRayMergeTool() :
-    m_maxDRSeparationFromTrack(1.5f), m_maxClusterSeparation(3.f), m_maxVertexSeparation(10.f), m_maxGoodMatchReducedChiSquared(1.f)
+    m_maxDRSeparationFromTrack(1.5f),
+    m_maxClusterSeparation(3.f),
+    m_maxVertexSeparation(10.f),
+    m_maxGoodMatchReducedChiSquared(1.f)
 {
 }
 
@@ -284,9 +287,9 @@ bool DeltaRayMergeTool::MakeOneCommonViewMerges(const TensorType::ElementList &e
                 if (element1.GetCluster(hitType) == element2.GetCluster(hitType))
                 {
                     const HitType mergeHitType1(hitType == TPC_VIEW_U ? TPC_VIEW_V : hitType == TPC_VIEW_V ? TPC_VIEW_W : TPC_VIEW_U);
-                    const HitType mergeHitType2(mergeHitType1 == TPC_VIEW_U   ? TPC_VIEW_V
-                                                : mergeHitType1 == TPC_VIEW_V ? TPC_VIEW_W
-                                                                              : TPC_VIEW_U);
+                    const HitType mergeHitType2(mergeHitType1 == TPC_VIEW_U ? TPC_VIEW_V
+                            : mergeHitType1 == TPC_VIEW_V                   ? TPC_VIEW_W
+                                                                            : TPC_VIEW_U);
 
                     const Cluster *pClusterToEnlarge1 = element1.GetCluster(mergeHitType1), *pClusterToDelete1 = element2.GetCluster(mergeHitType1);
                     const Cluster *pClusterToEnlarge2 = element1.GetCluster(mergeHitType2), *pClusterToDelete2 = element2.GetCluster(mergeHitType2);

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/DeltaRayParentAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/DeltaRayParentAlgorithm.cc
@@ -18,7 +18,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-DeltaRayParentAlgorithm::DeltaRayParentAlgorithm() : m_distanceForMatching(5.f)
+DeltaRayParentAlgorithm::DeltaRayParentAlgorithm() :
+    m_distanceForMatching(5.f)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/DeltaRayRemovalTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/DeltaRayRemovalTool.cc
@@ -138,7 +138,7 @@ bool DeltaRayRemovalTool::IsContaminated(const TensorType::Element &element, con
 
     const CartesianVector xAxis(1.f, 0.f, 0.f);
     const bool isTransverse((muonDirection.GetOpeningAngle(xAxis) < m_minDeviationFromTransverse) ||
-                            ((M_PI - muonDirection.GetOpeningAngle(xAxis)) < m_minDeviationFromTransverse));
+        ((M_PI - muonDirection.GetOpeningAngle(xAxis)) < m_minDeviationFromTransverse));
 
     if (isTransverse)
         return false;

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/NViewDeltaRayMatchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/NViewDeltaRayMatchingAlgorithm.cc
@@ -84,9 +84,9 @@ template <typename T>
 void NViewDeltaRayMatchingAlgorithm<T>::FillStrayClusterList(const HitType hitType)
 {
     const ClusterList &inputClusterList(this->GetInputClusterList(hitType));
-    ClusterList &strayClusterList((hitType == TPC_VIEW_U)   ? m_strayClusterListU
-                                  : (hitType == TPC_VIEW_V) ? m_strayClusterListV
-                                                            : m_strayClusterListW);
+    ClusterList &strayClusterList((hitType == TPC_VIEW_U) ? m_strayClusterListU
+            : (hitType == TPC_VIEW_V)                     ? m_strayClusterListV
+                                                          : m_strayClusterListW);
 
     for (const Cluster *const pCluster : inputClusterList)
     {
@@ -793,9 +793,9 @@ void NViewDeltaRayMatchingAlgorithm<T>::CollectStrayClusters(
     const Cluster *const pClusterToEnlarge, const float rangeMinX, const float rangeMaxX, ClusterList &collectedClusters)
 {
     const HitType hitType(LArClusterHelper::GetClusterHitType(pClusterToEnlarge));
-    const ClusterList &strayClusterList((hitType == TPC_VIEW_U)   ? m_strayClusterListU
-                                        : (hitType == TPC_VIEW_V) ? m_strayClusterListV
-                                                                  : m_strayClusterListW);
+    const ClusterList &strayClusterList((hitType == TPC_VIEW_U) ? m_strayClusterListU
+            : (hitType == TPC_VIEW_V)                           ? m_strayClusterListV
+                                                                : m_strayClusterListW);
     const DeltaRayMatchingContainers::ClusterProximityMap &clusterProximityMap(m_deltaRayMatchingContainers.GetClusterProximityMap(hitType));
     const DeltaRayMatchingContainers::ClusterProximityMap::const_iterator clusterProximityIter(clusterProximityMap.find(pClusterToEnlarge));
 
@@ -846,9 +846,9 @@ template <typename T>
 void NViewDeltaRayMatchingAlgorithm<T>::UpdateUponDeletion(const Cluster *const pDeletedCluster)
 {
     const HitType hitType(LArClusterHelper::GetClusterHitType(pDeletedCluster));
-    ClusterList &strayClusterList((hitType == TPC_VIEW_U)   ? m_strayClusterListU
-                                  : (hitType == TPC_VIEW_V) ? m_strayClusterListV
-                                                            : m_strayClusterListW);
+    ClusterList &strayClusterList((hitType == TPC_VIEW_U) ? m_strayClusterListU
+            : (hitType == TPC_VIEW_V)                     ? m_strayClusterListV
+                                                          : m_strayClusterListW);
     const ClusterList::const_iterator strayClusterIter(std::find(strayClusterList.begin(), strayClusterList.end(), pDeletedCluster));
 
     if (strayClusterIter != strayClusterList.end())

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/OneViewDeltaRayMatchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/OneViewDeltaRayMatchingAlgorithm.cc
@@ -20,7 +20,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-OneViewDeltaRayMatchingAlgorithm::OneViewDeltaRayMatchingAlgorithm() : m_overlapExtension(1.f), m_minClusterHits(3)
+OneViewDeltaRayMatchingAlgorithm::OneViewDeltaRayMatchingAlgorithm() :
+    m_overlapExtension(1.f),
+    m_minClusterHits(3)
 {
 }
 
@@ -51,9 +53,9 @@ StatusCode OneViewDeltaRayMatchingAlgorithm::Run()
 
 const ClusterList OneViewDeltaRayMatchingAlgorithm::GetInputClusterList(const HitType hitType)
 {
-    const std::string inputClusterListName((hitType == TPC_VIEW_U)   ? m_inputClusterListNameU
-                                           : (hitType == TPC_VIEW_V) ? m_inputClusterListNameV
-                                                                     : m_inputClusterListNameW);
+    const std::string inputClusterListName((hitType == TPC_VIEW_U) ? m_inputClusterListNameU
+            : (hitType == TPC_VIEW_V)                              ? m_inputClusterListNameV
+                                                                   : m_inputClusterListNameW);
 
     const ClusterList *pInputClusterList(nullptr);
 
@@ -193,9 +195,9 @@ bool OneViewDeltaRayMatchingAlgorithm::AddIntoExistingDeltaRay(const Cluster *co
 {
     const HitType hitType(LArClusterHelper::GetClusterHitType(pAvailableCluster));
     const HitType projectedHitType1((hitType == TPC_VIEW_U) ? TPC_VIEW_V : (hitType == TPC_VIEW_V) ? TPC_VIEW_W : TPC_VIEW_U);
-    const HitType projectedHitType2((projectedHitType1 == TPC_VIEW_U)   ? TPC_VIEW_V
-                                    : (projectedHitType1 == TPC_VIEW_V) ? TPC_VIEW_W
-                                                                        : TPC_VIEW_U);
+    const HitType projectedHitType2((projectedHitType1 == TPC_VIEW_U) ? TPC_VIEW_V
+            : (projectedHitType1 == TPC_VIEW_V)                       ? TPC_VIEW_W
+                                                                      : TPC_VIEW_U);
     const DeltaRayMatchingContainers::ClusterToPfoMap &clusterToPfoMap1(m_deltaRayMatchingContainers.GetClusterToPfoMap(projectedHitType1));
     const DeltaRayMatchingContainers::ClusterToPfoMap &clusterToPfoMap2(m_deltaRayMatchingContainers.GetClusterToPfoMap(projectedHitType2));
 
@@ -320,9 +322,9 @@ void OneViewDeltaRayMatchingAlgorithm::CreateDeltaRay(const Cluster *const pAvai
 
     const HitType hitType(LArClusterHelper::GetClusterHitType(pAvailableCluster));
     const HitType projectedHitType1((hitType == TPC_VIEW_U) ? TPC_VIEW_V : (hitType == TPC_VIEW_V) ? TPC_VIEW_W : TPC_VIEW_U);
-    const HitType projectedHitType2((projectedHitType1 == TPC_VIEW_U)   ? TPC_VIEW_V
-                                    : (projectedHitType1 == TPC_VIEW_V) ? TPC_VIEW_W
-                                                                        : TPC_VIEW_U);
+    const HitType projectedHitType2((projectedHitType1 == TPC_VIEW_U) ? TPC_VIEW_V
+            : (projectedHitType1 == TPC_VIEW_V)                       ? TPC_VIEW_W
+                                                                      : TPC_VIEW_U);
     ClusterList projectedClusters1, projectedClusters2;
 
     for (const ParticleFlowObject *const pNearbyMuonPfo : nearbyMuonPfoVector)
@@ -397,9 +399,9 @@ const Cluster *OneViewDeltaRayMatchingAlgorithm::MergeClusterGroup(const Cluster
         return pClusterToEnlarge;
 
     const HitType hitType(LArClusterHelper::GetClusterHitType(pClusterToEnlarge));
-    const std::string inputClusterListName((hitType == TPC_VIEW_U)   ? m_inputClusterListNameU
-                                           : (hitType == TPC_VIEW_V) ? m_inputClusterListNameV
-                                                                     : m_inputClusterListNameW);
+    const std::string inputClusterListName((hitType == TPC_VIEW_U) ? m_inputClusterListNameU
+            : (hitType == TPC_VIEW_V)                              ? m_inputClusterListNameV
+                                                                   : m_inputClusterListNameW);
 
     for (const Cluster *const pClusterToDelete : clusterGroup)
     {

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/RemovalBaseTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/RemovalBaseTool.cc
@@ -17,7 +17,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-RemovalBaseTool::RemovalBaseTool() : m_minSeparation(1.f), m_distanceToLine(0.5f)
+RemovalBaseTool::RemovalBaseTool() :
+    m_minSeparation(1.f),
+    m_distanceToLine(0.5f)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/ThreeViewDeltaRayMatchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/ThreeViewDeltaRayMatchingAlgorithm.cc
@@ -15,7 +15,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-ThreeViewDeltaRayMatchingAlgorithm::ThreeViewDeltaRayMatchingAlgorithm() : m_minClusterCaloHits(5), m_nMaxTensorToolRepeats(10)
+ThreeViewDeltaRayMatchingAlgorithm::ThreeViewDeltaRayMatchingAlgorithm() :
+    m_minClusterCaloHits(5),
+    m_nMaxTensorToolRepeats(10)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/TwoViewCosmicRayRemovalTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/TwoViewCosmicRayRemovalTool.cc
@@ -393,8 +393,8 @@ void TwoViewCosmicRayRemovalTool::CollectHitsFromDeltaRay(const CartesianVector 
                 continue;
 
             const float distanceToCollectedHits(collectedHits.empty()
-                                                    ? std::numeric_limits<float>::max()
-                                                    : LArClusterHelper::GetClosestDistance(pCaloHit->GetPositionVector(), collectedHits));
+                    ? std::numeric_limits<float>::max()
+                    : LArClusterHelper::GetClosestDistance(pCaloHit->GetPositionVector(), collectedHits));
             const float distanceToMuonHits(muonDirection.GetCrossProduct(pCaloHit->GetPositionVector() - positionOnMuon).GetMagnitude());
 
             if ((distanceToMuonHits < minDistanceFromMuon) || (demandCloserToCollected && (distanceToCollectedHits > distanceToMuonHits)))

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/UnambiguousDeltaRayTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/UnambiguousDeltaRayTool.cc
@@ -18,7 +18,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-UnambiguousDeltaRayTool::UnambiguousDeltaRayTool() : m_maxSeparation(2.f), m_minNConnectedClusters(1)
+UnambiguousDeltaRayTool::UnambiguousDeltaRayTool() :
+    m_maxSeparation(2.f),
+    m_minNConnectedClusters(1)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/BranchAssociatedPfosTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/BranchAssociatedPfosTool.cc
@@ -25,7 +25,9 @@ typedef NeutrinoHierarchyAlgorithm::PfoInfo PfoInfo;
 typedef NeutrinoHierarchyAlgorithm::PfoInfoMap PfoInfoMap;
 
 BranchAssociatedPfosTool::BranchAssociatedPfosTool() :
-    m_minNeutrinoVertexDistance(5.f), m_trackBranchAdditionFraction(0.4f), m_maxParentClusterDistance(3.5f)
+    m_minNeutrinoVertexDistance(5.f),
+    m_trackBranchAdditionFraction(0.4f),
+    m_maxParentClusterDistance(3.5f)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/EndAssociatedPfosTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/EndAssociatedPfosTool.cc
@@ -75,7 +75,7 @@ void EndAssociatedPfosTool::Run(const NeutrinoHierarchyAlgorithm *const pAlgorit
 
                 const LArPointingCluster pointingCluster(*(pPfoInfo->GetSlidingFitResult3D()));
                 const bool useInner((pointingCluster.GetInnerVertex().GetPosition() - parentEndpoint.GetPosition()).GetMagnitudeSquared() <
-                                    (pointingCluster.GetOuterVertex().GetPosition() - parentEndpoint.GetPosition()).GetMagnitudeSquared());
+                    (pointingCluster.GetOuterVertex().GetPosition() - parentEndpoint.GetPosition()).GetMagnitudeSquared());
 
                 const LArPointingCluster::Vertex &daughterVertex(useInner ? pointingCluster.GetInnerVertex() : pointingCluster.GetOuterVertex());
 

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/EventSlicingTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/EventSlicingTool.cc
@@ -238,8 +238,9 @@ void EventSlicingTool::CollectAssociatedClusters(const Cluster *const pClusterIn
 
         if ((m_usePointingAssociation && this->PassPointing(pClusterInSlice, pCandidateCluster, trackFitResults)) ||
             (m_useProximityAssociation && this->PassProximity(pClusterInSlice, pCandidateCluster)) ||
-            (m_useShowerConeAssociation && (this->PassShowerCone(pClusterInSlice, pCandidateCluster, showerConeFitResults) ||
-                                               this->PassShowerCone(pCandidateCluster, pClusterInSlice, showerConeFitResults))))
+            (m_useShowerConeAssociation &&
+                (this->PassShowerCone(pClusterInSlice, pCandidateCluster, showerConeFitResults) ||
+                    this->PassShowerCone(pCandidateCluster, pClusterInSlice, showerConeFitResults))))
         {
             addedClusters.push_back(pCandidateCluster);
             (void)usedClusters.insert(pCandidateCluster);
@@ -345,9 +346,9 @@ bool EventSlicingTool::PassShowerCone(
 bool EventSlicingTool::CheckClosestApproach(const LArPointingCluster &cluster1, const LArPointingCluster &cluster2) const
 {
     return (this->CheckClosestApproach(cluster1.GetInnerVertex(), cluster2.GetInnerVertex()) ||
-            this->CheckClosestApproach(cluster1.GetOuterVertex(), cluster2.GetInnerVertex()) ||
-            this->CheckClosestApproach(cluster1.GetInnerVertex(), cluster2.GetOuterVertex()) ||
-            this->CheckClosestApproach(cluster1.GetOuterVertex(), cluster2.GetOuterVertex()));
+        this->CheckClosestApproach(cluster1.GetOuterVertex(), cluster2.GetInnerVertex()) ||
+        this->CheckClosestApproach(cluster1.GetInnerVertex(), cluster2.GetOuterVertex()) ||
+        this->CheckClosestApproach(cluster1.GetOuterVertex(), cluster2.GetOuterVertex()));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -371,7 +372,7 @@ bool EventSlicingTool::CheckClosestApproach(const LArPointingCluster::Vertex &ve
     const float closestApproach((approach1 - approach2).GetMagnitude());
 
     return ((closestApproach < m_maxClosestApproach) && (std::fabs(displacement1) < m_maxInterceptDistance) &&
-            (std::fabs(displacement2) < m_maxInterceptDistance));
+        (std::fabs(displacement2) < m_maxInterceptDistance));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -380,20 +381,20 @@ bool EventSlicingTool::IsNode(const LArPointingCluster &cluster1, const LArPoint
 {
     return (LArPointingClusterHelper::IsNode(cluster1.GetInnerVertex().GetPosition(), cluster2.GetInnerVertex(),
                 m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-            LArPointingClusterHelper::IsNode(cluster1.GetOuterVertex().GetPosition(), cluster2.GetInnerVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-            LArPointingClusterHelper::IsNode(cluster1.GetInnerVertex().GetPosition(), cluster2.GetOuterVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-            LArPointingClusterHelper::IsNode(cluster1.GetOuterVertex().GetPosition(), cluster2.GetOuterVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-            LArPointingClusterHelper::IsNode(cluster2.GetInnerVertex().GetPosition(), cluster1.GetInnerVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-            LArPointingClusterHelper::IsNode(cluster2.GetOuterVertex().GetPosition(), cluster1.GetInnerVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-            LArPointingClusterHelper::IsNode(cluster2.GetInnerVertex().GetPosition(), cluster1.GetOuterVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-            LArPointingClusterHelper::IsNode(cluster2.GetOuterVertex().GetPosition(), cluster1.GetOuterVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance));
+        LArPointingClusterHelper::IsNode(cluster1.GetOuterVertex().GetPosition(), cluster2.GetInnerVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+        LArPointingClusterHelper::IsNode(cluster1.GetInnerVertex().GetPosition(), cluster2.GetOuterVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+        LArPointingClusterHelper::IsNode(cluster1.GetOuterVertex().GetPosition(), cluster2.GetOuterVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+        LArPointingClusterHelper::IsNode(cluster2.GetInnerVertex().GetPosition(), cluster1.GetInnerVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+        LArPointingClusterHelper::IsNode(cluster2.GetOuterVertex().GetPosition(), cluster1.GetInnerVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+        LArPointingClusterHelper::IsNode(cluster2.GetInnerVertex().GetPosition(), cluster1.GetOuterVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+        LArPointingClusterHelper::IsNode(cluster2.GetOuterVertex().GetPosition(), cluster1.GetOuterVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -402,20 +403,20 @@ bool EventSlicingTool::IsEmission(const LArPointingCluster &cluster1, const LArP
 {
     return (LArPointingClusterHelper::IsEmission(cluster1.GetInnerVertex().GetPosition(), cluster2.GetInnerVertex(),
                 m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-            LArPointingClusterHelper::IsEmission(cluster1.GetOuterVertex().GetPosition(), cluster2.GetInnerVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-            LArPointingClusterHelper::IsEmission(cluster1.GetInnerVertex().GetPosition(), cluster2.GetOuterVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-            LArPointingClusterHelper::IsEmission(cluster1.GetOuterVertex().GetPosition(), cluster2.GetOuterVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-            LArPointingClusterHelper::IsEmission(cluster2.GetInnerVertex().GetPosition(), cluster1.GetInnerVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-            LArPointingClusterHelper::IsEmission(cluster2.GetOuterVertex().GetPosition(), cluster1.GetInnerVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-            LArPointingClusterHelper::IsEmission(cluster2.GetInnerVertex().GetPosition(), cluster1.GetOuterVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-            LArPointingClusterHelper::IsEmission(cluster2.GetOuterVertex().GetPosition(), cluster1.GetOuterVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance));
+        LArPointingClusterHelper::IsEmission(cluster1.GetOuterVertex().GetPosition(), cluster2.GetInnerVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+        LArPointingClusterHelper::IsEmission(cluster1.GetInnerVertex().GetPosition(), cluster2.GetOuterVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+        LArPointingClusterHelper::IsEmission(cluster1.GetOuterVertex().GetPosition(), cluster2.GetOuterVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+        LArPointingClusterHelper::IsEmission(cluster2.GetInnerVertex().GetPosition(), cluster1.GetInnerVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+        LArPointingClusterHelper::IsEmission(cluster2.GetOuterVertex().GetPosition(), cluster1.GetInnerVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+        LArPointingClusterHelper::IsEmission(cluster2.GetInnerVertex().GetPosition(), cluster1.GetOuterVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+        LArPointingClusterHelper::IsEmission(cluster2.GetOuterVertex().GetPosition(), cluster1.GetOuterVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -467,9 +468,9 @@ void EventSlicingTool::CopyPfoHitsToSlices(const ClusterToSliceIndexMap &cluster
             if ((TPC_VIEW_U != hitType) && (TPC_VIEW_V != hitType) && (TPC_VIEW_W != hitType))
                 throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
-            CaloHitList &targetList((TPC_VIEW_U == hitType)   ? slice.m_caloHitListU
-                                    : (TPC_VIEW_V == hitType) ? slice.m_caloHitListV
-                                                              : slice.m_caloHitListW);
+            CaloHitList &targetList((TPC_VIEW_U == hitType) ? slice.m_caloHitListU
+                    : (TPC_VIEW_V == hitType)               ? slice.m_caloHitListV
+                                                            : slice.m_caloHitListW);
 
             pCluster2D->GetOrderedCaloHitList().FillCaloHitList(targetList);
             targetList.insert(targetList.end(), pCluster2D->GetIsolatedCaloHitList().begin(), pCluster2D->GetIsolatedCaloHitList().end());
@@ -570,9 +571,9 @@ void EventSlicingTool::AssignRemainingHitsToSlices(
                 continue;
 
             Slice &slice(sliceList.at(pointToSliceIndexMap.at(pBestResultPoint->data)));
-            CaloHitList &targetList((TPC_VIEW_U == hitType)   ? slice.m_caloHitListU
-                                    : (TPC_VIEW_V == hitType) ? slice.m_caloHitListV
-                                                              : slice.m_caloHitListW);
+            CaloHitList &targetList((TPC_VIEW_U == hitType) ? slice.m_caloHitListU
+                    : (TPC_VIEW_V == hitType)               ? slice.m_caloHitListV
+                                                            : slice.m_caloHitListW);
 
             pCluster2D->GetOrderedCaloHitList().FillCaloHitList(targetList);
             targetList.insert(targetList.end(), pCluster2D->GetIsolatedCaloHitList().begin(), pCluster2D->GetIsolatedCaloHitList().end());

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoCreationAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoCreationAlgorithm.cc
@@ -19,7 +19,8 @@ namespace lar_content
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-NeutrinoCreationAlgorithm::NeutrinoCreationAlgorithm() : m_forceSingleEmptyNeutrino(false)
+NeutrinoCreationAlgorithm::NeutrinoCreationAlgorithm() :
+    m_forceSingleEmptyNeutrino(false)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoDaughterVerticesAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoDaughterVerticesAlgorithm.cc
@@ -19,7 +19,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-NeutrinoDaughterVerticesAlgorithm::NeutrinoDaughterVerticesAlgorithm() : m_useParentShowerVertex(false), m_halfWindowLayers(20)
+NeutrinoDaughterVerticesAlgorithm::NeutrinoDaughterVerticesAlgorithm() :
+    m_useParentShowerVertex(false),
+    m_halfWindowLayers(20)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoHierarchyAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoHierarchyAlgorithm.cc
@@ -19,7 +19,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-NeutrinoHierarchyAlgorithm::NeutrinoHierarchyAlgorithm() : m_halfWindowLayers(20), m_displayPfoInfoMap(false)
+NeutrinoHierarchyAlgorithm::NeutrinoHierarchyAlgorithm() :
+    m_halfWindowLayers(20),
+    m_displayPfoInfoMap(false)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoPropertiesAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoPropertiesAlgorithm.cc
@@ -18,7 +18,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-NeutrinoPropertiesAlgorithm::NeutrinoPropertiesAlgorithm() : m_includeIsolatedHits(false)
+NeutrinoPropertiesAlgorithm::NeutrinoPropertiesAlgorithm() :
+    m_includeIsolatedHits(false)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/VertexAssociatedPfosTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/VertexAssociatedPfosTool.cc
@@ -25,7 +25,10 @@ typedef NeutrinoHierarchyAlgorithm::PfoInfo PfoInfo;
 typedef NeutrinoHierarchyAlgorithm::PfoInfoMap PfoInfoMap;
 
 VertexAssociatedPfosTool::VertexAssociatedPfosTool() :
-    m_minVertexLongitudinalDistance(-2.5f), m_maxVertexLongitudinalDistance(20.f), m_maxVertexTransverseDistance(3.5f), m_vertexAngularAllowance(3.f)
+    m_minVertexLongitudinalDistance(-2.5f),
+    m_maxVertexLongitudinalDistance(20.f),
+    m_maxVertexTransverseDistance(3.5f),
+    m_vertexAngularAllowance(3.f)
 {
 }
 
@@ -52,7 +55,7 @@ void VertexAssociatedPfosTool::Run(const NeutrinoHierarchyAlgorithm *const pAlgo
 
         const LArPointingCluster pointingCluster(*(pPfoInfo->GetSlidingFitResult3D()));
         const bool useInner((pointingCluster.GetInnerVertex().GetPosition() - neutrinoVertex).GetMagnitudeSquared() <
-                            (pointingCluster.GetOuterVertex().GetPosition() - neutrinoVertex).GetMagnitudeSquared());
+            (pointingCluster.GetOuterVertex().GetPosition() - neutrinoVertex).GetMagnitudeSquared());
 
         const LArPointingCluster::Vertex &daughterVertex(useInner ? pointingCluster.GetInnerVertex() : pointingCluster.GetOuterVertex());
 

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/HitCreationBaseTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/HitCreationBaseTool.cc
@@ -17,7 +17,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-HitCreationBaseTool::HitCreationBaseTool() : m_sigmaX2(1.), m_chiSquaredCut(1.)
+HitCreationBaseTool::HitCreationBaseTool() :
+    m_sigmaX2(1.),
+    m_chiSquaredCut(1.)
 {
 }
 
@@ -83,15 +85,15 @@ void HitCreationBaseTool::GetBestPosition3D(const HitType hitType1, const HitTyp
     CartesianVector position3D(0.f, 0.f, 0.f);
     double chi2(std::numeric_limits<double>::max());
 
-    const double u((TPC_VIEW_U == hitType)    ? pCaloHit2D->GetPositionVector().GetZ()
-                   : (TPC_VIEW_U == hitType1) ? fitPosition1.GetZ()
-                                              : fitPosition2.GetZ());
-    const double v((TPC_VIEW_V == hitType)    ? pCaloHit2D->GetPositionVector().GetZ()
-                   : (TPC_VIEW_V == hitType1) ? fitPosition1.GetZ()
-                                              : fitPosition2.GetZ());
-    const double w((TPC_VIEW_W == hitType)    ? pCaloHit2D->GetPositionVector().GetZ()
-                   : (TPC_VIEW_W == hitType1) ? fitPosition1.GetZ()
-                                              : fitPosition2.GetZ());
+    const double u((TPC_VIEW_U == hitType) ? pCaloHit2D->GetPositionVector().GetZ()
+            : (TPC_VIEW_U == hitType1)     ? fitPosition1.GetZ()
+                                           : fitPosition2.GetZ());
+    const double v((TPC_VIEW_V == hitType) ? pCaloHit2D->GetPositionVector().GetZ()
+            : (TPC_VIEW_V == hitType1)     ? fitPosition1.GetZ()
+                                           : fitPosition2.GetZ());
+    const double w((TPC_VIEW_W == hitType) ? pCaloHit2D->GetPositionVector().GetZ()
+            : (TPC_VIEW_W == hitType1)     ? fitPosition1.GetZ()
+                                           : fitPosition2.GetZ());
 
     const double sigmaU((TPC_VIEW_U == hitType) ? sigmaHit : sigmaFit);
     const double sigmaV((TPC_VIEW_V == hitType) ? sigmaHit : sigmaFit);

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/LongitudinalTrackHitsBaseTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/LongitudinalTrackHitsBaseTool.cc
@@ -19,7 +19,8 @@ namespace lar_content
 {
 
 LongitudinalTrackHitsBaseTool::LongitudinalTrackHitsBaseTool() :
-    m_vtxDisplacementCutSquared(5.f * 5.f), m_minTrackLengthSquared(7.5f * 7.5f)
+    m_vtxDisplacementCutSquared(5.f * 5.f),
+    m_minTrackLengthSquared(7.5f * 7.5f)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/ShowerHitsBaseTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/ShowerHitsBaseTool.cc
@@ -18,7 +18,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-ShowerHitsBaseTool::ShowerHitsBaseTool() : m_xTolerance(1.f)
+ShowerHitsBaseTool::ShowerHitsBaseTool() :
+    m_xTolerance(1.f)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/ThreeDHitCreationAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/ThreeDHitCreationAlgorithm.cc
@@ -222,7 +222,7 @@ double ThreeDHitCreationAlgorithm::GetChi2WrtFit(const ThreeDSlidingFitResult &s
 
         const double deltaUFit(uFit - outputU), deltaVFit(vFit - outputV), deltaWFit(wFit - outputW);
         chi2WrtFit += ((deltaUFit * deltaUFit) / (sigma3DFit * sigma3DFit)) + ((deltaVFit * deltaVFit) / (sigma3DFit * sigma3DFit)) +
-                      ((deltaWFit * deltaWFit) / (sigma3DFit * sigma3DFit));
+            ((deltaWFit * deltaWFit) / (sigma3DFit * sigma3DFit));
     }
 
     return chi2WrtFit;

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/ThreeDHitCreationAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/ThreeDHitCreationAlgorithm.h
@@ -287,7 +287,9 @@ private:
 
 inline ThreeDHitCreationAlgorithm::TrajectorySample::TrajectorySample(
     const pandora::CartesianVector &position, const pandora::HitType hitType, const double sigma) :
-    m_position(position), m_hitType(hitType), m_sigma(sigma)
+    m_position(position),
+    m_hitType(hitType),
+    m_sigma(sigma)
 {
 }
 
@@ -316,7 +318,10 @@ inline double ThreeDHitCreationAlgorithm::TrajectorySample::GetSigma() const
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline ThreeDHitCreationAlgorithm::ProtoHit::ProtoHit(const pandora::CaloHit *const pParentCaloHit2D) :
-    m_pParentCaloHit2D(pParentCaloHit2D), m_isPositionSet(false), m_position3D(0.f, 0.f, 0.f), m_chi2(std::numeric_limits<double>::max())
+    m_pParentCaloHit2D(pParentCaloHit2D),
+    m_isPositionSet(false),
+    m_position3D(0.f, 0.f, 0.f),
+    m_chi2(std::numeric_limits<double>::max())
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/ThreeViewShowerHitsTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/ThreeViewShowerHitsTool.cc
@@ -17,7 +17,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-ThreeViewShowerHitsTool::ThreeViewShowerHitsTool() : m_zTolerance(1.f)
+ThreeViewShowerHitsTool::ThreeViewShowerHitsTool() :
+    m_zTolerance(1.f)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/TrackHitsBaseTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/TrackHitsBaseTool.cc
@@ -20,7 +20,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-TrackHitsBaseTool::TrackHitsBaseTool() : m_minViews(2), m_slidingFitWindow(20)
+TrackHitsBaseTool::TrackHitsBaseTool() :
+    m_minViews(2),
+    m_slidingFitWindow(20)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/ClearLongitudinalTracksTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/ClearLongitudinalTracksTool.cc
@@ -15,7 +15,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-ClearLongitudinalTracksTool::ClearLongitudinalTracksTool() : m_minMatchedFraction(0.8f)
+ClearLongitudinalTracksTool::ClearLongitudinalTracksTool() :
+    m_minMatchedFraction(0.8f)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/MatchedEndPointsTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/MatchedEndPointsTool.cc
@@ -15,7 +15,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-MatchedEndPointsTool::MatchedEndPointsTool() : m_minMatchedFraction(0.8f), m_maxEndPointChi2(3.f)
+MatchedEndPointsTool::MatchedEndPointsTool() :
+    m_minMatchedFraction(0.8f),
+    m_maxEndPointChi2(3.f)
 {
 }
 
@@ -84,7 +86,7 @@ void MatchedEndPointsTool::FindMatchedTracks(const TensorType &overlapTensor, Pr
 bool MatchedEndPointsTool::SortByChiSquared(const TensorType::Element &lhs, const TensorType::Element &rhs)
 {
     return (lhs.GetOverlapResult().GetInnerChi2() + lhs.GetOverlapResult().GetOuterChi2() <
-            rhs.GetOverlapResult().GetInnerChi2() + rhs.GetOverlapResult().GetOuterChi2());
+        rhs.GetOverlapResult().GetInnerChi2() + rhs.GetOverlapResult().GetOuterChi2());
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/ThreeViewLongitudinalTracksAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/ThreeViewLongitudinalTracksAlgorithm.cc
@@ -19,7 +19,10 @@ namespace lar_content
 {
 
 ThreeViewLongitudinalTracksAlgorithm::ThreeViewLongitudinalTracksAlgorithm() :
-    m_nMaxTensorToolRepeats(1000), m_vertexChi2Cut(10.f), m_reducedChi2Cut(5.f), m_samplingPitch(1.f)
+    m_nMaxTensorToolRepeats(1000),
+    m_vertexChi2Cut(10.f),
+    m_reducedChi2Cut(5.f),
+    m_samplingPitch(1.f)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.h
@@ -75,14 +75,16 @@ private:
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline RecursivePfoMopUpAlgorithm::RecursivePfoMopUpAlgorithm() : m_maxIterations(10)
+inline RecursivePfoMopUpAlgorithm::RecursivePfoMopUpAlgorithm() :
+    m_maxIterations(10)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline RecursivePfoMopUpAlgorithm::PfoMergeStats::PfoMergeStats(const ClusterNumHitsList &numClusterHits, const float trackScore) :
-    m_numClusterHits(numClusterHits), m_trackScore(trackScore)
+    m_numClusterHits(numClusterHits),
+    m_trackScore(trackScore)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerPfoMopUpAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerPfoMopUpAlgorithm.cc
@@ -22,7 +22,9 @@ namespace lar_content
 {
 
 ShowerPfoMopUpAlgorithm::ShowerPfoMopUpAlgorithm() :
-    VertexBasedPfoMopUpAlgorithm(), m_maxVertexLongitudinalDistance(20.f), m_vertexAngularAllowance(3.f)
+    VertexBasedPfoMopUpAlgorithm(),
+    m_maxVertexLongitudinalDistance(20.f),
+    m_vertexAngularAllowance(3.f)
 {
     // ATTN Some default values differ from base class
     m_maxVertexTransverseDistance = 3.5f;
@@ -38,11 +40,11 @@ ShowerPfoMopUpAlgorithm::ShowerPfoMopUpAlgorithm() :
 bool ShowerPfoMopUpAlgorithm::IsVertexAssociated(const CartesianVector &vertex2D, const LArPointingCluster &pointingCluster) const
 {
     return (LArPointingClusterHelper::IsNode(vertex2D, pointingCluster.GetInnerVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-            LArPointingClusterHelper::IsNode(vertex2D, pointingCluster.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-            LArPointingClusterHelper::IsEmission(vertex2D, pointingCluster.GetInnerVertex(), m_minVertexLongitudinalDistance,
-                m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-            LArPointingClusterHelper::IsEmission(vertex2D, pointingCluster.GetOuterVertex(), m_minVertexLongitudinalDistance,
-                m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance));
+        LArPointingClusterHelper::IsNode(vertex2D, pointingCluster.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+        LArPointingClusterHelper::IsEmission(vertex2D, pointingCluster.GetInnerVertex(), m_minVertexLongitudinalDistance,
+            m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+        LArPointingClusterHelper::IsEmission(vertex2D, pointingCluster.GetOuterVertex(), m_minVertexLongitudinalDistance,
+            m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/SlidingConePfoMopUpAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/SlidingConePfoMopUpAlgorithm.cc
@@ -156,9 +156,9 @@ void SlidingConePfoMopUpAlgorithm::GetClusterMergeMap(const Vertex *const pVerte
 
             const float vertexToMinLayer(!pVertex ? 0.f : (pVertex->GetPosition() - minLayerPosition).GetMagnitude());
             const float vertexToMaxLayer(!pVertex ? 0.f : (pVertex->GetPosition() - maxLayerPosition).GetMagnitude());
-            const ConeSelection coneSelection(!pVertex                                ? CONE_BOTH_DIRECTIONS
-                                              : (vertexToMaxLayer > vertexToMinLayer) ? CONE_FORWARD_ONLY
-                                                                                      : CONE_BACKWARD_ONLY);
+            const ConeSelection coneSelection(!pVertex      ? CONE_BOTH_DIRECTIONS
+                    : (vertexToMaxLayer > vertexToMinLayer) ? CONE_FORWARD_ONLY
+                                                            : CONE_BACKWARD_ONLY);
 
             slidingConeFitResult3D.GetSimpleConeList(m_nConeFitLayers, m_nConeFits, coneSelection, simpleConeList);
             isShowerVertexAssociated =
@@ -241,7 +241,7 @@ bool SlidingConePfoMopUpAlgorithm::IsVertexAssociated(
             pSlidingFitResult ? LArPointingCluster(*pSlidingFitResult) : LArPointingCluster(pCluster, m_halfWindowLayers, layerPitch));
 
         const bool useInner((pointingCluster.GetInnerVertex().GetPosition() - vertexPosition).GetMagnitudeSquared() <
-                            (pointingCluster.GetOuterVertex().GetPosition() - vertexPosition).GetMagnitudeSquared());
+            (pointingCluster.GetOuterVertex().GetPosition() - vertexPosition).GetMagnitudeSquared());
 
         const LArPointingCluster::Vertex &daughterVertex(useInner ? pointingCluster.GetInnerVertex() : pointingCluster.GetOuterVertex());
         return LArPointingClusterHelper::IsNode(vertexPosition, daughterVertex, m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance);

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/SlidingConePfoMopUpAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/SlidingConePfoMopUpAlgorithm.h
@@ -175,7 +175,9 @@ private:
 
 inline SlidingConePfoMopUpAlgorithm::ClusterMerge::ClusterMerge(
     const pandora::Cluster *const pParentCluster, const float boundedFraction1, const float boundedFraction2) :
-    m_pParentCluster(pParentCluster), m_boundedFraction1(boundedFraction1), m_boundedFraction2(boundedFraction2)
+    m_pParentCluster(pParentCluster),
+    m_boundedFraction1(boundedFraction1),
+    m_boundedFraction2(boundedFraction2)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/VertexBasedPfoMopUpAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/VertexBasedPfoMopUpAlgorithm.cc
@@ -81,7 +81,7 @@ StatusCode VertexBasedPfoMopUpAlgorithm::Run()
 bool VertexBasedPfoMopUpAlgorithm::IsVertexAssociated(const CartesianVector &vertex2D, const LArPointingCluster &pointingCluster) const
 {
     return (LArPointingClusterHelper::IsNode(vertex2D, pointingCluster.GetInnerVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-            LArPointingClusterHelper::IsNode(vertex2D, pointingCluster.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance));
+        LArPointingClusterHelper::IsNode(vertex2D, pointingCluster.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -296,7 +296,10 @@ void VertexBasedPfoMopUpAlgorithm::MergePfos(const PfoAssociation &pfoAssociatio
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 VertexBasedPfoMopUpAlgorithm::ClusterAssociation::ClusterAssociation() :
-    m_pVertexCluster(nullptr), m_pDaughterCluster(nullptr), m_boundedFraction(0.f), m_isConsistentDirection(false)
+    m_pVertexCluster(nullptr),
+    m_pDaughterCluster(nullptr),
+    m_boundedFraction(0.f),
+    m_isConsistentDirection(false)
 {
 }
 
@@ -304,7 +307,10 @@ VertexBasedPfoMopUpAlgorithm::ClusterAssociation::ClusterAssociation() :
 
 VertexBasedPfoMopUpAlgorithm::ClusterAssociation::ClusterAssociation(const Cluster *const pVertexCluster,
     const Cluster *const pDaughterCluster, const float boundedFraction, const bool isConsistentDirection) :
-    m_pVertexCluster(pVertexCluster), m_pDaughterCluster(pDaughterCluster), m_boundedFraction(boundedFraction), m_isConsistentDirection(isConsistentDirection)
+    m_pVertexCluster(pVertexCluster),
+    m_pDaughterCluster(pDaughterCluster),
+    m_boundedFraction(boundedFraction),
+    m_isConsistentDirection(isConsistentDirection)
 {
 }
 
@@ -327,7 +333,7 @@ float VertexBasedPfoMopUpAlgorithm::PfoAssociation::GetMeanBoundedFraction() con
 {
     return ((this->GetClusterAssociationU().GetBoundedFraction() + this->GetClusterAssociationV().GetBoundedFraction() +
                 this->GetClusterAssociationW().GetBoundedFraction()) /
-            3.f);
+        3.f);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -382,7 +388,11 @@ bool VertexBasedPfoMopUpAlgorithm::PfoAssociation::operator<(const PfoAssociatio
 
 VertexBasedPfoMopUpAlgorithm::ConeParameters::ConeParameters(
     const Cluster *const pCluster, const CartesianVector &vertexPosition2D, const float coneAngleCentile, const float maxCosHalfAngle) :
-    m_pCluster(pCluster), m_apex(vertexPosition2D), m_direction(0.f, 0.f, 0.f), m_coneLength(0.f), m_coneCosHalfAngle(0.f)
+    m_pCluster(pCluster),
+    m_apex(vertexPosition2D),
+    m_direction(0.f, 0.f, 0.f),
+    m_coneLength(0.f),
+    m_coneCosHalfAngle(0.f)
 {
     m_direction = this->GetDirectionEstimate();
     m_coneLength = this->GetSignedConeLength();

--- a/larpandoracontent/LArThreeDReco/LArPfoRecovery/ParticleRecoveryAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoRecovery/ParticleRecoveryAlgorithm.cc
@@ -85,9 +85,9 @@ void ParticleRecoveryAlgorithm::GetInputClusters(ClusterList &inputClusterListU,
             if ((TPC_VIEW_U != hitType) && (TPC_VIEW_V != hitType) && (TPC_VIEW_W != hitType))
                 throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
-            ClusterList &clusterList((TPC_VIEW_U == hitType)   ? inputClusterListU
-                                     : (TPC_VIEW_V == hitType) ? inputClusterListV
-                                                               : inputClusterListW);
+            ClusterList &clusterList((TPC_VIEW_U == hitType) ? inputClusterListU
+                    : (TPC_VIEW_V == hitType)                ? inputClusterListV
+                                                             : inputClusterListW);
             clusterList.push_back(pCluster);
         }
     }
@@ -460,9 +460,9 @@ void ParticleRecoveryAlgorithm::SimpleOverlapTensor::GetConnectedElements(const 
         throw StatusCodeException(STATUS_CODE_FAILURE);
 
     ClusterList &clusterList((TPC_VIEW_U == hitType) ? clusterListU : (TPC_VIEW_V == hitType) ? clusterListV : clusterListW);
-    const ClusterNavigationMap &navigationMap((TPC_VIEW_U == hitType)   ? m_clusterNavigationMapUV
-                                              : (TPC_VIEW_V == hitType) ? m_clusterNavigationMapVW
-                                                                        : m_clusterNavigationMapWU);
+    const ClusterNavigationMap &navigationMap((TPC_VIEW_U == hitType) ? m_clusterNavigationMapUV
+            : (TPC_VIEW_V == hitType)                                 ? m_clusterNavigationMapVW
+                                                                      : m_clusterNavigationMapWU);
 
     if (clusterList.end() != std::find(clusterList.begin(), clusterList.end(), pCluster))
         return;

--- a/larpandoracontent/LArThreeDReco/LArPfoRecovery/VertexBasedPfoRecoveryAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoRecovery/VertexBasedPfoRecoveryAlgorithm.cc
@@ -20,7 +20,11 @@ namespace lar_content
 {
 
 VertexBasedPfoRecoveryAlgorithm::VertexBasedPfoRecoveryAlgorithm() :
-    m_slidingFitHalfWindow(10), m_maxLongitudinalDisplacement(5.f), m_maxTransverseDisplacement(2.f), m_twoViewChi2Cut(5.f), m_threeViewChi2Cut(5.f)
+    m_slidingFitHalfWindow(10),
+    m_maxLongitudinalDisplacement(5.f),
+    m_maxTransverseDisplacement(2.f),
+    m_twoViewChi2Cut(5.f),
+    m_threeViewChi2Cut(5.f)
 {
 }
 
@@ -201,18 +205,18 @@ void VertexBasedPfoRecoveryAlgorithm::MatchThreeViews(const Vertex *const pVerte
         const HitType hitType2(LArClusterHelper::GetClusterHitType(pCluster2));
         const HitType hitType3(LArClusterHelper::GetClusterHitType(pCluster3));
 
-        const Cluster *const pClusterU((TPC_VIEW_U == hitType1)   ? pCluster1
-                                       : (TPC_VIEW_U == hitType2) ? pCluster2
-                                       : (TPC_VIEW_U == hitType3) ? pCluster3
-                                                                  : NULL);
-        const Cluster *const pClusterV((TPC_VIEW_V == hitType1)   ? pCluster1
-                                       : (TPC_VIEW_V == hitType2) ? pCluster2
-                                       : (TPC_VIEW_V == hitType3) ? pCluster3
-                                                                  : NULL);
-        const Cluster *const pClusterW((TPC_VIEW_W == hitType1)   ? pCluster1
-                                       : (TPC_VIEW_W == hitType2) ? pCluster2
-                                       : (TPC_VIEW_W == hitType3) ? pCluster3
-                                                                  : NULL);
+        const Cluster *const pClusterU((TPC_VIEW_U == hitType1) ? pCluster1
+                : (TPC_VIEW_U == hitType2)                      ? pCluster2
+                : (TPC_VIEW_U == hitType3)                      ? pCluster3
+                                                                : NULL);
+        const Cluster *const pClusterV((TPC_VIEW_V == hitType1) ? pCluster1
+                : (TPC_VIEW_V == hitType2)                      ? pCluster2
+                : (TPC_VIEW_V == hitType3)                      ? pCluster3
+                                                                : NULL);
+        const Cluster *const pClusterW((TPC_VIEW_W == hitType1) ? pCluster1
+                : (TPC_VIEW_W == hitType2)                      ? pCluster2
+                : (TPC_VIEW_W == hitType3)                      ? pCluster3
+                                                                : NULL);
 
         particleList.push_back(Particle(pClusterU, pClusterV, pClusterW));
 
@@ -519,7 +523,9 @@ void VertexBasedPfoRecoveryAlgorithm::BuildParticles(const ParticleList &particl
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 VertexBasedPfoRecoveryAlgorithm::Particle::Particle(const Cluster *const pClusterU, const Cluster *const pClusterV, const Cluster *const pClusterW) :
-    m_pClusterU(pClusterU), m_pClusterV(pClusterV), m_pClusterW(pClusterW)
+    m_pClusterU(pClusterU),
+    m_pClusterV(pClusterV),
+    m_pClusterW(pClusterW)
 {
     if (NULL == m_pClusterU && NULL == m_pClusterV && NULL == m_pClusterW)
         throw StatusCodeException(STATUS_CODE_FAILURE);

--- a/larpandoracontent/LArThreeDReco/LArShowerFragments/ConnectedRemnantsTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArShowerFragments/ConnectedRemnantsTool.cc
@@ -17,7 +17,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-ConnectedRemnantsTool::ConnectedRemnantsTool() : m_maxClusterSeparation(10.f)
+ConnectedRemnantsTool::ConnectedRemnantsTool() :
+    m_maxClusterSeparation(10.f)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArShowerFragments/ThreeViewRemnantsAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArShowerFragments/ThreeViewRemnantsAlgorithm.cc
@@ -19,7 +19,10 @@ namespace lar_content
 {
 
 ThreeViewRemnantsAlgorithm::ThreeViewRemnantsAlgorithm() :
-    m_nMaxTensorToolRepeats(1000), m_minClusterCaloHits(5), m_xOverlapWindow(2.f), m_pseudoChi2Cut(10.f)
+    m_nMaxTensorToolRepeats(1000),
+    m_minClusterCaloHits(5),
+    m_xOverlapWindow(2.f),
+    m_pseudoChi2Cut(10.f)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArShowerMatching/SimpleShowersTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArShowerMatching/SimpleShowersTool.cc
@@ -15,7 +15,10 @@ using namespace pandora;
 namespace lar_content
 {
 
-SimpleShowersTool::SimpleShowersTool() : m_minMatchedFraction(0.2f), m_minMatchedSamplingPoints(40), m_minXOverlapFraction(0.5f)
+SimpleShowersTool::SimpleShowersTool() :
+    m_minMatchedFraction(0.2f),
+    m_minMatchedSamplingPoints(40),
+    m_minXOverlapFraction(0.5f)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArShowerMatching/SplitShowersTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArShowerMatching/SplitShowersTool.cc
@@ -189,9 +189,9 @@ void SplitShowersTool::FindShowerMerges(ThreeViewShowersAlgorithm *const pAlgori
                     continue;
                 }
 
-                if (m_checkClusterVertexRelations && (!this->CheckClusterVertexRelations(pAlgorithm, clusterListU) ||
-                                                         !this->CheckClusterVertexRelations(pAlgorithm, clusterListV) ||
-                                                         !this->CheckClusterVertexRelations(pAlgorithm, clusterListW)))
+                if (m_checkClusterVertexRelations &&
+                    (!this->CheckClusterVertexRelations(pAlgorithm, clusterListU) || !this->CheckClusterVertexRelations(pAlgorithm, clusterListV) ||
+                        !this->CheckClusterVertexRelations(pAlgorithm, clusterListW)))
                 {
                     continue;
                 }

--- a/larpandoracontent/LArThreeDReco/LArThreeDBase/NViewMatchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArThreeDBase/NViewMatchingAlgorithm.cc
@@ -24,7 +24,8 @@ namespace lar_content
 {
 
 template <typename T>
-NViewMatchingAlgorithm<T>::NViewMatchingAlgorithm() : m_matchingControl(this)
+NViewMatchingAlgorithm<T>::NViewMatchingAlgorithm() :
+    m_matchingControl(this)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArThreeDBase/NViewMatchingControl.h
+++ b/larpandoracontent/LArThreeDReco/LArThreeDBase/NViewMatchingControl.h
@@ -107,7 +107,8 @@ protected:
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline NViewMatchingControl::NViewMatchingControl(MatchingBaseAlgorithm *const pAlgorithm) : m_pAlgorithm(pAlgorithm)
+inline NViewMatchingControl::NViewMatchingControl(MatchingBaseAlgorithm *const pAlgorithm) :
+    m_pAlgorithm(pAlgorithm)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArThreeDBase/NViewTrackMatchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArThreeDBase/NViewTrackMatchingAlgorithm.cc
@@ -26,7 +26,9 @@ namespace lar_content
 
 template <typename T>
 NViewTrackMatchingAlgorithm<T>::NViewTrackMatchingAlgorithm() :
-    m_slidingFitWindow(20), m_minClusterCaloHits(5), m_minClusterLengthSquared(3.f * 3.f)
+    m_slidingFitWindow(20),
+    m_minClusterCaloHits(5),
+    m_minClusterLengthSquared(3.f * 3.f)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArThreeDBase/ThreeViewMatchingControl.cc
+++ b/larpandoracontent/LArThreeDReco/LArThreeDBase/ThreeViewMatchingControl.cc
@@ -23,7 +23,10 @@ namespace lar_content
 
 template <typename T>
 ThreeViewMatchingControl<T>::ThreeViewMatchingControl(MatchingBaseAlgorithm *const pAlgorithm) :
-    NViewMatchingControl(pAlgorithm), m_pInputClusterListU(nullptr), m_pInputClusterListV(nullptr), m_pInputClusterListW(nullptr)
+    NViewMatchingControl(pAlgorithm),
+    m_pInputClusterListU(nullptr),
+    m_pInputClusterListV(nullptr),
+    m_pInputClusterListW(nullptr)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArThreeDBase/TwoViewMatchingControl.cc
+++ b/larpandoracontent/LArThreeDReco/LArThreeDBase/TwoViewMatchingControl.cc
@@ -22,7 +22,9 @@ namespace lar_content
 
 template <typename T>
 TwoViewMatchingControl<T>::TwoViewMatchingControl(MatchingBaseAlgorithm *const pAlgorithm) :
-    NViewMatchingControl(pAlgorithm), m_pInputClusterList1(nullptr), m_pInputClusterList2(nullptr)
+    NViewMatchingControl(pAlgorithm),
+    m_pInputClusterList1(nullptr),
+    m_pInputClusterList2(nullptr)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArTrackFragments/ClearTrackFragmentsTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTrackFragments/ClearTrackFragmentsTool.cc
@@ -17,7 +17,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-ClearTrackFragmentsTool::ClearTrackFragmentsTool() : m_minMatchedSamplingPointFraction(0.5f), m_minMatchedHits(5)
+ClearTrackFragmentsTool::ClearTrackFragmentsTool() :
+    m_minMatchedSamplingPointFraction(0.5f),
+    m_minMatchedHits(5)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArTrackFragments/ThreeViewTrackFragmentsAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArTrackFragments/ThreeViewTrackFragmentsAlgorithm.cc
@@ -51,9 +51,9 @@ void ThreeViewTrackFragmentsAlgorithm::UpdateForNewCluster(const Cluster *const 
 
     // ATTN This is non-standard usage, supported here only (for legacy purposes)
     MatchingType &matchingControl(this->GetMatchingControl());
-    ClusterList &clusterList((TPC_VIEW_U == hitType)   ? matchingControl.m_clusterListU
-                             : (TPC_VIEW_V == hitType) ? matchingControl.m_clusterListV
-                                                       : matchingControl.m_clusterListW);
+    ClusterList &clusterList((TPC_VIEW_U == hitType) ? matchingControl.m_clusterListU
+            : (TPC_VIEW_V == hitType)                ? matchingControl.m_clusterListV
+                                                     : matchingControl.m_clusterListW);
 
     if (clusterList.end() != std::find(clusterList.begin(), clusterList.end(), pNewCluster))
         throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
@@ -147,10 +147,10 @@ void ThreeViewTrackFragmentsAlgorithm::PerformMainLoop()
 
 void ThreeViewTrackFragmentsAlgorithm::CalculateOverlapResult(const Cluster *const pClusterU, const Cluster *const pClusterV, const Cluster *const pClusterW)
 {
-    const HitType missingHitType(((nullptr != pClusterU) && (nullptr != pClusterV) && (nullptr == pClusterW))   ? TPC_VIEW_W
-                                 : ((nullptr != pClusterU) && (nullptr == pClusterV) && (nullptr != pClusterW)) ? TPC_VIEW_V
-                                 : ((nullptr == pClusterU) && (nullptr != pClusterV) && (nullptr != pClusterW)) ? TPC_VIEW_U
-                                                                                                                : HIT_CUSTOM);
+    const HitType missingHitType(((nullptr != pClusterU) && (nullptr != pClusterV) && (nullptr == pClusterW)) ? TPC_VIEW_W
+            : ((nullptr != pClusterU) && (nullptr == pClusterV) && (nullptr != pClusterW))                    ? TPC_VIEW_V
+            : ((nullptr == pClusterU) && (nullptr != pClusterV) && (nullptr != pClusterW))                    ? TPC_VIEW_U
+                                                                                                              : HIT_CUSTOM);
 
     if (HIT_CUSTOM == missingHitType)
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
@@ -162,9 +162,9 @@ void ThreeViewTrackFragmentsAlgorithm::CalculateOverlapResult(const Cluster *con
     const TwoDSlidingFitResult &fitResult1(
         (TPC_VIEW_U == missingHitType) ? this->GetCachedSlidingFitResult(pClusterV) : this->GetCachedSlidingFitResult(pClusterU));
 
-    const TwoDSlidingFitResult &fitResult2((TPC_VIEW_U == missingHitType)   ? this->GetCachedSlidingFitResult(pClusterW)
-                                           : (TPC_VIEW_V == missingHitType) ? this->GetCachedSlidingFitResult(pClusterW)
-                                                                            : this->GetCachedSlidingFitResult(pClusterV));
+    const TwoDSlidingFitResult &fitResult2((TPC_VIEW_U == missingHitType) ? this->GetCachedSlidingFitResult(pClusterW)
+            : (TPC_VIEW_V == missingHitType)                              ? this->GetCachedSlidingFitResult(pClusterW)
+                                                                          : this->GetCachedSlidingFitResult(pClusterV));
 
     const ClusterList &inputClusterList(this->GetInputClusterList(missingHitType));
 
@@ -278,10 +278,10 @@ StatusCode ThreeViewTrackFragmentsAlgorithm::GetProjectedPositions(
     // Check hit types
     const HitType hitType1(LArClusterHelper::GetClusterHitType(pCluster1));
     const HitType hitType2(LArClusterHelper::GetClusterHitType(pCluster2));
-    const HitType hitType3((TPC_VIEW_U != hitType1 && TPC_VIEW_U != hitType2)   ? TPC_VIEW_U
-                           : (TPC_VIEW_V != hitType1 && TPC_VIEW_V != hitType2) ? TPC_VIEW_V
-                           : (TPC_VIEW_W != hitType1 && TPC_VIEW_W != hitType2) ? TPC_VIEW_W
-                                                                                : HIT_CUSTOM);
+    const HitType hitType3((TPC_VIEW_U != hitType1 && TPC_VIEW_U != hitType2) ? TPC_VIEW_U
+            : (TPC_VIEW_V != hitType1 && TPC_VIEW_V != hitType2)              ? TPC_VIEW_V
+            : (TPC_VIEW_W != hitType1 && TPC_VIEW_W != hitType2)              ? TPC_VIEW_W
+                                                                              : HIT_CUSTOM);
 
     if (HIT_CUSTOM == hitType3)
         return STATUS_CODE_INVALID_PARAMETER;

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/ClearTracksTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/ClearTracksTool.cc
@@ -14,7 +14,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-ClearTracksTool::ClearTracksTool() : m_minMatchedFraction(0.9f), m_minXOverlapFraction(0.9f)
+ClearTracksTool::ClearTracksTool() :
+    m_minMatchedFraction(0.9f),
+    m_minXOverlapFraction(0.9f)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/LongTracksTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/LongTracksTool.cc
@@ -16,7 +16,10 @@ namespace lar_content
 {
 
 LongTracksTool::LongTracksTool() :
-    m_minMatchedFraction(0.9f), m_minMatchedSamplingPoints(20), m_minXOverlapFraction(0.9f), m_minMatchedSamplingPointRatio(2)
+    m_minMatchedFraction(0.9f),
+    m_minMatchedSamplingPoints(20),
+    m_minXOverlapFraction(0.9f),
+    m_minMatchedSamplingPointRatio(2)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/MissingTrackSegmentTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/MissingTrackSegmentTool.cc
@@ -120,9 +120,9 @@ void MissingTrackSegmentTool::SelectElements(
         const XOverlap &xOverlap(eIter->GetOverlapResult().GetXOverlap());
         const float shortSpan(std::min(xOverlap.GetXSpanU(), std::min(xOverlap.GetXSpanV(), xOverlap.GetXSpanW())));
         const float longSpan1(std::max(xOverlap.GetXSpanU(), std::max(xOverlap.GetXSpanV(), xOverlap.GetXSpanW())));
-        const float longSpan2(((xOverlap.GetXSpanU() > shortSpan) && (xOverlap.GetXSpanU() < longSpan1))   ? xOverlap.GetXSpanU()
-                              : ((xOverlap.GetXSpanV() > shortSpan) && (xOverlap.GetXSpanV() < longSpan1)) ? xOverlap.GetXSpanV()
-                                                                                                           : xOverlap.GetXSpanW());
+        const float longSpan2(((xOverlap.GetXSpanU() > shortSpan) && (xOverlap.GetXSpanU() < longSpan1)) ? xOverlap.GetXSpanU()
+                : ((xOverlap.GetXSpanV() > shortSpan) && (xOverlap.GetXSpanV() < longSpan1))             ? xOverlap.GetXSpanV()
+                                                                                                         : xOverlap.GetXSpanW());
 
         if ((xOverlap.GetXOverlapSpan() < std::numeric_limits<float>::epsilon()) || (longSpan1 < std::numeric_limits<float>::epsilon()))
             continue;
@@ -385,31 +385,31 @@ MissingTrackSegmentTool::Particle::Particle(const TensorType::Element &element)
 {
     const XOverlap &xOverlap(element.GetOverlapResult().GetXOverlap());
 
-    m_shortHitType = ((xOverlap.GetXSpanU() < xOverlap.GetXSpanV()) && (xOverlap.GetXSpanU() < xOverlap.GetXSpanW()))   ? TPC_VIEW_U
-                     : ((xOverlap.GetXSpanV() < xOverlap.GetXSpanU()) && (xOverlap.GetXSpanV() < xOverlap.GetXSpanW())) ? TPC_VIEW_V
-                     : ((xOverlap.GetXSpanW() < xOverlap.GetXSpanU()) && (xOverlap.GetXSpanW() < xOverlap.GetXSpanV())) ? TPC_VIEW_W
-                                                                                                                        : HIT_CUSTOM;
+    m_shortHitType = ((xOverlap.GetXSpanU() < xOverlap.GetXSpanV()) && (xOverlap.GetXSpanU() < xOverlap.GetXSpanW())) ? TPC_VIEW_U
+        : ((xOverlap.GetXSpanV() < xOverlap.GetXSpanU()) && (xOverlap.GetXSpanV() < xOverlap.GetXSpanW()))            ? TPC_VIEW_V
+        : ((xOverlap.GetXSpanW() < xOverlap.GetXSpanU()) && (xOverlap.GetXSpanW() < xOverlap.GetXSpanV()))            ? TPC_VIEW_W
+                                                                                                                      : HIT_CUSTOM;
 
     if (HIT_CUSTOM == m_shortHitType)
         throw StatusCodeException(STATUS_CODE_FAILURE);
 
-    m_pShortCluster = (TPC_VIEW_U == m_shortHitType)   ? element.GetClusterU()
-                      : (TPC_VIEW_V == m_shortHitType) ? element.GetClusterV()
-                                                       : element.GetClusterW();
+    m_pShortCluster = (TPC_VIEW_U == m_shortHitType) ? element.GetClusterU()
+        : (TPC_VIEW_V == m_shortHitType)             ? element.GetClusterV()
+                                                     : element.GetClusterW();
     m_pCluster1 = (TPC_VIEW_U == m_shortHitType) ? element.GetClusterV() : element.GetClusterU();
     m_pCluster2 = (TPC_VIEW_W == m_shortHitType) ? element.GetClusterV() : element.GetClusterW();
-    m_shortMinX = (TPC_VIEW_U == m_shortHitType)   ? xOverlap.GetUMinX()
-                  : (TPC_VIEW_V == m_shortHitType) ? xOverlap.GetVMinX()
-                                                   : xOverlap.GetWMinX();
-    m_shortMaxX = (TPC_VIEW_U == m_shortHitType)   ? xOverlap.GetUMaxX()
-                  : (TPC_VIEW_V == m_shortHitType) ? xOverlap.GetVMaxX()
-                                                   : xOverlap.GetWMaxX();
-    m_longMinX = (TPC_VIEW_U == m_shortHitType)   ? std::min(xOverlap.GetVMinX(), xOverlap.GetWMinX())
-                 : (TPC_VIEW_V == m_shortHitType) ? std::min(xOverlap.GetUMinX(), xOverlap.GetWMinX())
-                                                  : std::min(xOverlap.GetUMinX(), xOverlap.GetVMinX());
-    m_longMaxX = (TPC_VIEW_U == m_shortHitType)   ? std::max(xOverlap.GetVMaxX(), xOverlap.GetWMaxX())
-                 : (TPC_VIEW_V == m_shortHitType) ? std::max(xOverlap.GetUMaxX(), xOverlap.GetWMaxX())
-                                                  : std::max(xOverlap.GetUMaxX(), xOverlap.GetVMaxX());
+    m_shortMinX = (TPC_VIEW_U == m_shortHitType) ? xOverlap.GetUMinX()
+        : (TPC_VIEW_V == m_shortHitType)         ? xOverlap.GetVMinX()
+                                                 : xOverlap.GetWMinX();
+    m_shortMaxX = (TPC_VIEW_U == m_shortHitType) ? xOverlap.GetUMaxX()
+        : (TPC_VIEW_V == m_shortHitType)         ? xOverlap.GetVMaxX()
+                                                 : xOverlap.GetWMaxX();
+    m_longMinX = (TPC_VIEW_U == m_shortHitType) ? std::min(xOverlap.GetVMinX(), xOverlap.GetWMinX())
+        : (TPC_VIEW_V == m_shortHitType)        ? std::min(xOverlap.GetUMinX(), xOverlap.GetWMinX())
+                                                : std::min(xOverlap.GetUMinX(), xOverlap.GetVMinX());
+    m_longMaxX = (TPC_VIEW_U == m_shortHitType) ? std::max(xOverlap.GetVMaxX(), xOverlap.GetWMaxX())
+        : (TPC_VIEW_V == m_shortHitType)        ? std::max(xOverlap.GetUMaxX(), xOverlap.GetWMaxX())
+                                                : std::max(xOverlap.GetUMaxX(), xOverlap.GetVMaxX());
 
     m_hitType1 = LArClusterHelper::GetClusterHitType(m_pCluster1);
     m_hitType2 = LArClusterHelper::GetClusterHitType(m_pCluster2);

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/MissingTrackTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/MissingTrackTool.cc
@@ -15,7 +15,10 @@ namespace lar_content
 {
 
 MissingTrackTool::MissingTrackTool() :
-    m_minMatchedSamplingPoints(15), m_minMatchedFraction(0.95f), m_maxReducedChiSquared(0.707f), m_minXOverlapFraction(0.75f)
+    m_minMatchedSamplingPoints(15),
+    m_minMatchedFraction(0.95f),
+    m_maxReducedChiSquared(0.707f),
+    m_minXOverlapFraction(0.75f)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/OvershootTracksTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/OvershootTracksTool.cc
@@ -20,7 +20,10 @@ namespace lar_content
 {
 
 OvershootTracksTool::OvershootTracksTool() :
-    ThreeDKinkBaseTool(1), m_splitMode(true), m_maxVertexXSeparation(2.f), m_cosThetaCutForKinkSearch(0.94f)
+    ThreeDKinkBaseTool(1),
+    m_splitMode(true),
+    m_maxVertexXSeparation(2.f),
+    m_cosThetaCutForKinkSearch(0.94f)
 {
 }
 
@@ -215,27 +218,29 @@ bool OvershootTracksTool::IsThreeDKink(
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 OvershootTracksTool::Particle::Particle(const TensorType::Element &elementA, const TensorType::Element &elementB) :
-    m_splitPosition(0.f, 0.f, 0.f), m_splitPosition1(0.f, 0.f, 0.f), m_splitPosition2(0.f, 0.f, 0.f)
+    m_splitPosition(0.f, 0.f, 0.f),
+    m_splitPosition1(0.f, 0.f, 0.f),
+    m_splitPosition2(0.f, 0.f, 0.f)
 {
-    const HitType commonView((elementA.GetClusterU() == elementB.GetClusterU())   ? TPC_VIEW_U
-                             : (elementA.GetClusterV() == elementB.GetClusterV()) ? TPC_VIEW_V
-                             : (elementA.GetClusterW() == elementB.GetClusterW()) ? TPC_VIEW_W
-                                                                                  : HIT_CUSTOM);
+    const HitType commonView((elementA.GetClusterU() == elementB.GetClusterU()) ? TPC_VIEW_U
+            : (elementA.GetClusterV() == elementB.GetClusterV())                ? TPC_VIEW_V
+            : (elementA.GetClusterW() == elementB.GetClusterW())                ? TPC_VIEW_W
+                                                                                : HIT_CUSTOM);
 
     if (HIT_CUSTOM == commonView)
         throw StatusCodeException(STATUS_CODE_FAILURE);
 
-    m_pCommonCluster = (TPC_VIEW_U == commonView)   ? elementA.GetClusterU()
-                       : (TPC_VIEW_V == commonView) ? elementA.GetClusterV()
-                                                    : elementA.GetClusterW();
+    m_pCommonCluster = (TPC_VIEW_U == commonView) ? elementA.GetClusterU()
+        : (TPC_VIEW_V == commonView)              ? elementA.GetClusterV()
+                                                  : elementA.GetClusterW();
     m_pClusterA1 = (TPC_VIEW_U == commonView) ? elementA.GetClusterV() : elementA.GetClusterU();
-    m_pClusterA2 = (TPC_VIEW_U == commonView)   ? elementA.GetClusterW()
-                   : (TPC_VIEW_V == commonView) ? elementA.GetClusterW()
-                                                : elementA.GetClusterV();
+    m_pClusterA2 = (TPC_VIEW_U == commonView) ? elementA.GetClusterW()
+        : (TPC_VIEW_V == commonView)          ? elementA.GetClusterW()
+                                              : elementA.GetClusterV();
     m_pClusterB1 = (TPC_VIEW_U == commonView) ? elementB.GetClusterV() : elementB.GetClusterU();
-    m_pClusterB2 = (TPC_VIEW_U == commonView)   ? elementB.GetClusterW()
-                   : (TPC_VIEW_V == commonView) ? elementB.GetClusterW()
-                                                : elementB.GetClusterV();
+    m_pClusterB2 = (TPC_VIEW_U == commonView) ? elementB.GetClusterW()
+        : (TPC_VIEW_V == commonView)          ? elementB.GetClusterW()
+                                              : elementB.GetClusterV();
 
     if ((m_pClusterA1 == m_pClusterB1) || (m_pClusterA2 == m_pClusterB2))
         throw StatusCodeException(STATUS_CODE_FAILURE);

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/ThreeViewTransverseTracksAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/ThreeViewTransverseTracksAlgorithm.cc
@@ -104,8 +104,8 @@ void ThreeViewTransverseTracksAlgorithm::GetFitSegmentTensor(const TwoDSlidingFi
                 const FitSegment &fitSegmentW(fitSegmentListW.at(indexW));
 
                 TransverseOverlapResult segmentOverlap;
-                if (STATUS_CODE_SUCCESS != this->GetSegmentOverlap(fitSegmentU, fitSegmentV, fitSegmentW, slidingFitResultU,
-                                               slidingFitResultV, slidingFitResultW, segmentOverlap))
+                if (STATUS_CODE_SUCCESS !=
+                    this->GetSegmentOverlap(fitSegmentU, fitSegmentV, fitSegmentW, slidingFitResultU, slidingFitResultV, slidingFitResultW, segmentOverlap))
                     continue;
 
                 if ((segmentOverlap.GetMatchedFraction() < m_minSegmentMatchedFraction) ||

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/TrackSplittingTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/TrackSplittingTool.cc
@@ -108,9 +108,9 @@ void TrackSplittingTool::SelectElements(const TensorType::ElementList &elementLi
         const XOverlap &xOverlap(eIter->GetOverlapResult().GetXOverlap());
         const float longSpan(std::max(xOverlap.GetXSpanU(), std::max(xOverlap.GetXSpanV(), xOverlap.GetXSpanW())));
         const float shortSpan1(std::min(xOverlap.GetXSpanU(), std::min(xOverlap.GetXSpanV(), xOverlap.GetXSpanW())));
-        const float shortSpan2(((xOverlap.GetXSpanU() > shortSpan1) && (xOverlap.GetXSpanU() < longSpan))   ? xOverlap.GetXSpanU()
-                               : ((xOverlap.GetXSpanV() > shortSpan1) && (xOverlap.GetXSpanV() < longSpan)) ? xOverlap.GetXSpanV()
-                                                                                                            : xOverlap.GetXSpanW());
+        const float shortSpan2(((xOverlap.GetXSpanU() > shortSpan1) && (xOverlap.GetXSpanU() < longSpan)) ? xOverlap.GetXSpanU()
+                : ((xOverlap.GetXSpanV() > shortSpan1) && (xOverlap.GetXSpanV() < longSpan))              ? xOverlap.GetXSpanV()
+                                                                                                          : xOverlap.GetXSpanW());
 
         if ((shortSpan1 < std::numeric_limits<float>::epsilon()) || (longSpan < std::numeric_limits<float>::epsilon()))
             continue;
@@ -231,24 +231,24 @@ TrackSplittingTool::Particle::Particle(const TensorType::Element &element)
     const XOverlap &xOverlap(element.GetOverlapResult().GetXOverlap());
 
     const HitType longHitType = ((xOverlap.GetXSpanU() > xOverlap.GetXSpanV()) && (xOverlap.GetXSpanU() > xOverlap.GetXSpanW())) ? TPC_VIEW_U
-                                : ((xOverlap.GetXSpanV() > xOverlap.GetXSpanU()) && (xOverlap.GetXSpanV() > xOverlap.GetXSpanW())) ? TPC_VIEW_V
-                                : ((xOverlap.GetXSpanW() > xOverlap.GetXSpanU()) && (xOverlap.GetXSpanW() > xOverlap.GetXSpanV())) ? TPC_VIEW_W
-                                                                                                                                   : HIT_CUSTOM;
+        : ((xOverlap.GetXSpanV() > xOverlap.GetXSpanU()) && (xOverlap.GetXSpanV() > xOverlap.GetXSpanW())) ? TPC_VIEW_V
+        : ((xOverlap.GetXSpanW() > xOverlap.GetXSpanU()) && (xOverlap.GetXSpanW() > xOverlap.GetXSpanV())) ? TPC_VIEW_W
+                                                                                                           : HIT_CUSTOM;
 
     if (HIT_CUSTOM == longHitType)
         throw StatusCodeException(STATUS_CODE_FAILURE);
 
-    m_pLongCluster = (TPC_VIEW_U == longHitType)   ? element.GetClusterU()
-                     : (TPC_VIEW_V == longHitType) ? element.GetClusterV()
-                                                   : element.GetClusterW();
+    m_pLongCluster = (TPC_VIEW_U == longHitType) ? element.GetClusterU()
+        : (TPC_VIEW_V == longHitType)            ? element.GetClusterV()
+                                                 : element.GetClusterW();
     m_pCluster1 = (TPC_VIEW_U == longHitType) ? element.GetClusterV() : element.GetClusterU();
     m_pCluster2 = (TPC_VIEW_W == longHitType) ? element.GetClusterV() : element.GetClusterW();
-    m_longMinX = (TPC_VIEW_U == longHitType)   ? xOverlap.GetUMinX()
-                 : (TPC_VIEW_V == longHitType) ? xOverlap.GetVMinX()
-                                               : xOverlap.GetWMinX();
-    m_longMaxX = (TPC_VIEW_U == longHitType)   ? xOverlap.GetUMaxX()
-                 : (TPC_VIEW_V == longHitType) ? xOverlap.GetVMaxX()
-                                               : xOverlap.GetWMaxX();
+    m_longMinX = (TPC_VIEW_U == longHitType) ? xOverlap.GetUMinX()
+        : (TPC_VIEW_V == longHitType)        ? xOverlap.GetVMinX()
+                                             : xOverlap.GetWMinX();
+    m_longMaxX = (TPC_VIEW_U == longHitType) ? xOverlap.GetUMaxX()
+        : (TPC_VIEW_V == longHitType)        ? xOverlap.GetVMaxX()
+                                             : xOverlap.GetWMaxX();
     m_short1MinX = (TPC_VIEW_U == longHitType) ? xOverlap.GetVMinX() : xOverlap.GetUMinX();
     m_short1MaxX = (TPC_VIEW_U == longHitType) ? xOverlap.GetVMaxX() : xOverlap.GetUMaxX();
     m_short2MinX = (TPC_VIEW_W == longHitType) ? xOverlap.GetVMinX() : xOverlap.GetWMinX();

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/TracksCrossingGapsTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/TracksCrossingGapsTool.cc
@@ -299,7 +299,7 @@ bool TracksCrossingGapsTool::CheckXPositionInGap(const float xSample, const TwoD
 bool TracksCrossingGapsTool::IsEndOfCluster(const float xSample, const TwoDSlidingFitResult &slidingFitResult) const
 {
     return ((std::fabs(slidingFitResult.GetGlobalMinLayerPosition().GetX() - xSample) < slidingFitResult.GetLayerPitch()) ||
-            (std::fabs(slidingFitResult.GetGlobalMaxLayerPosition().GetX() - xSample) < slidingFitResult.GetLayerPitch()));
+        (std::fabs(slidingFitResult.GetGlobalMaxLayerPosition().GetX() - xSample) < slidingFitResult.GetLayerPitch()));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/UndershootTracksTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/UndershootTracksTool.cc
@@ -22,7 +22,11 @@ namespace lar_content
 {
 
 UndershootTracksTool::UndershootTracksTool() :
-    ThreeDKinkBaseTool(2), m_splitMode(false), m_maxTransverseImpactParameter(5.f), m_minImpactParameterCosTheta(0.5f), m_cosThetaCutForKinkSearch(0.75f)
+    ThreeDKinkBaseTool(2),
+    m_splitMode(false),
+    m_maxTransverseImpactParameter(5.f),
+    m_minImpactParameterCosTheta(0.5f),
+    m_cosThetaCutForKinkSearch(0.75f)
 {
 }
 
@@ -186,18 +190,18 @@ bool UndershootTracksTool::IsThreeDKink(ThreeViewTransverseTracksAlgorithm *cons
 
 UndershootTracksTool::Particle::Particle(const TensorType::Element &elementA, const TensorType::Element &elementB)
 {
-    m_pClusterA = (elementA.GetClusterU() != elementB.GetClusterU())   ? elementA.GetClusterU()
-                  : (elementA.GetClusterV() != elementB.GetClusterV()) ? elementA.GetClusterV()
-                                                                       : elementA.GetClusterW();
-    m_pClusterB = (elementA.GetClusterU() != elementB.GetClusterU())   ? elementB.GetClusterU()
-                  : (elementA.GetClusterV() != elementB.GetClusterV()) ? elementB.GetClusterV()
-                                                                       : elementB.GetClusterW();
-    m_pCommonCluster1 = (elementA.GetClusterU() == elementB.GetClusterU())   ? elementA.GetClusterU()
-                        : (elementA.GetClusterV() == elementB.GetClusterV()) ? elementA.GetClusterV()
-                                                                             : elementA.GetClusterW();
+    m_pClusterA = (elementA.GetClusterU() != elementB.GetClusterU()) ? elementA.GetClusterU()
+        : (elementA.GetClusterV() != elementB.GetClusterV())         ? elementA.GetClusterV()
+                                                                     : elementA.GetClusterW();
+    m_pClusterB = (elementA.GetClusterU() != elementB.GetClusterU()) ? elementB.GetClusterU()
+        : (elementA.GetClusterV() != elementB.GetClusterV())         ? elementB.GetClusterV()
+                                                                     : elementB.GetClusterW();
+    m_pCommonCluster1 = (elementA.GetClusterU() == elementB.GetClusterU()) ? elementA.GetClusterU()
+        : (elementA.GetClusterV() == elementB.GetClusterV())               ? elementA.GetClusterV()
+                                                                           : elementA.GetClusterW();
     m_pCommonCluster2 = ((m_pClusterA != elementA.GetClusterU()) && (m_pCommonCluster1 != elementA.GetClusterU())) ? elementA.GetClusterU()
-                        : ((m_pClusterA != elementA.GetClusterV()) && (m_pCommonCluster1 != elementA.GetClusterV())) ? elementA.GetClusterV()
-                                                                                                                     : elementA.GetClusterW();
+        : ((m_pClusterA != elementA.GetClusterV()) && (m_pCommonCluster1 != elementA.GetClusterV()))               ? elementA.GetClusterV()
+                                                                                                                   : elementA.GetClusterW();
 
     if ((m_pClusterA == m_pClusterB) || (m_pCommonCluster1 == m_pCommonCluster2))
         throw StatusCodeException(STATUS_CODE_FAILURE);

--- a/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewClearTracksTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewClearTracksTool.cc
@@ -17,7 +17,10 @@ using namespace pandora;
 namespace lar_content
 {
 
-TwoViewClearTracksTool::TwoViewClearTracksTool() : m_minXOverlapFraction(0.1f), m_minMatchingScore(0.95f), m_minLocallyMatchedFraction(0.3f)
+TwoViewClearTracksTool::TwoViewClearTracksTool() :
+    m_minXOverlapFraction(0.1f),
+    m_minMatchingScore(0.95f),
+    m_minLocallyMatchedFraction(0.3f)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewLongTracksTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewLongTracksTool.cc
@@ -16,7 +16,11 @@ namespace lar_content
 {
 
 TwoViewLongTracksTool::TwoViewLongTracksTool() :
-    m_minMatchedFraction(0.3f), m_minMatchingScore(0.95f), m_minMatchedSamplingPoints(15), m_minXOverlapFraction(0.9f), m_minMatchedSamplingPointRatio(2)
+    m_minMatchedFraction(0.3f),
+    m_minMatchingScore(0.95f),
+    m_minMatchedSamplingPoints(15),
+    m_minXOverlapFraction(0.9f),
+    m_minMatchedSamplingPointRatio(2)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewSimpleTracksTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewSimpleTracksTool.cc
@@ -16,7 +16,10 @@ namespace lar_content
 {
 
 TwoViewSimpleTracksTool::TwoViewSimpleTracksTool() :
-    m_minMatchedFraction(0.2f), m_minMatchingScore(0.9f), m_minMatchedSamplingPoints(5), m_minXOverlapFraction(0.5f)
+    m_minMatchedFraction(0.2f),
+    m_minMatchingScore(0.9f),
+    m_minMatchedSamplingPoints(5),
+    m_minXOverlapFraction(0.5f)
 {
 }
 

--- a/larpandoracontent/LArTrackShowerId/BranchGrowingAlgorithm.h
+++ b/larpandoracontent/LArTrackShowerId/BranchGrowingAlgorithm.h
@@ -126,13 +126,17 @@ protected:
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline BranchGrowingAlgorithm::Association::Association() : m_order(std::numeric_limits<unsigned int>::max()), m_type(NONE)
+inline BranchGrowingAlgorithm::Association::Association() :
+    m_order(std::numeric_limits<unsigned int>::max()),
+    m_type(NONE)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline BranchGrowingAlgorithm::Association::Association(const unsigned int order, const AssociationType type) : m_order(order), m_type(type)
+inline BranchGrowingAlgorithm::Association::Association(const unsigned int order, const AssociationType type) :
+    m_order(order),
+    m_type(type)
 {
 }
 

--- a/larpandoracontent/LArTrackShowerId/ClusterCharacterisationBaseAlgorithm.cc
+++ b/larpandoracontent/LArTrackShowerId/ClusterCharacterisationBaseAlgorithm.cc
@@ -19,7 +19,9 @@ namespace lar_content
 {
 
 ClusterCharacterisationBaseAlgorithm::ClusterCharacterisationBaseAlgorithm() :
-    m_zeroMode(false), m_overwriteExistingId(false), m_useUnavailableClusters(false)
+    m_zeroMode(false),
+    m_overwriteExistingId(false),
+    m_useUnavailableClusters(false)
 {
 }
 

--- a/larpandoracontent/LArTrackShowerId/PfoCharacterisationBaseAlgorithm.cc
+++ b/larpandoracontent/LArTrackShowerId/PfoCharacterisationBaseAlgorithm.cc
@@ -21,7 +21,10 @@ namespace lar_content
 {
 
 PfoCharacterisationBaseAlgorithm::PfoCharacterisationBaseAlgorithm() :
-    m_updateClusterIds(true), m_postBranchAddition(false), m_useThreeDInformation(true), m_minTrackLikeViews(2)
+    m_updateClusterIds(true),
+    m_postBranchAddition(false),
+    m_useThreeDInformation(true),
+    m_minTrackLikeViews(2)
 {
 }
 

--- a/larpandoracontent/LArTrackShowerId/ShowerGrowingAlgorithm.cc
+++ b/larpandoracontent/LArTrackShowerId/ShowerGrowingAlgorithm.cc
@@ -40,11 +40,11 @@ ShowerGrowingAlgorithm::ShowerGrowingAlgorithm() :
 bool ShowerGrowingAlgorithm::IsVertexAssociated(const LArPointingCluster &pointingCluster, const CartesianVector &vertexPosition2D) const
 {
     return (LArPointingClusterHelper::IsNode(vertexPosition2D, pointingCluster.GetInnerVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-            LArPointingClusterHelper::IsNode(vertexPosition2D, pointingCluster.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-            LArPointingClusterHelper::IsEmission(vertexPosition2D, pointingCluster.GetInnerVertex(), m_minVertexLongitudinalDistance,
-                m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-            LArPointingClusterHelper::IsEmission(vertexPosition2D, pointingCluster.GetOuterVertex(), m_minVertexLongitudinalDistance,
-                m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance));
+        LArPointingClusterHelper::IsNode(vertexPosition2D, pointingCluster.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+        LArPointingClusterHelper::IsEmission(vertexPosition2D, pointingCluster.GetInnerVertex(), m_minVertexLongitudinalDistance,
+            m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+        LArPointingClusterHelper::IsEmission(vertexPosition2D, pointingCluster.GetOuterVertex(), m_minVertexLongitudinalDistance,
+            m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -285,9 +285,9 @@ ShowerGrowingAlgorithm::AssociationType ShowerGrowingAlgorithm::AreClustersAssoc
 
     if (m_clusterDirectionMap.end() == seedIter)
     {
-        const LArVertexHelper::ClusterDirection direction((nullptr == pVertex) ? LArVertexHelper::DIRECTION_UNKNOWN
-                                                                               : LArVertexHelper::GetClusterDirectionInZ(this->GetPandora(), pVertex,
-                                                                                     pClusterSeed, m_directionTanAngle, m_directionApexShift));
+        const LArVertexHelper::ClusterDirection direction((nullptr == pVertex)
+                ? LArVertexHelper::DIRECTION_UNKNOWN
+                : LArVertexHelper::GetClusterDirectionInZ(this->GetPandora(), pVertex, pClusterSeed, m_directionTanAngle, m_directionApexShift));
         seedIter = m_clusterDirectionMap.insert(ClusterDirectionMap::value_type(pClusterSeed, direction)).first;
     }
 
@@ -300,9 +300,9 @@ ShowerGrowingAlgorithm::AssociationType ShowerGrowingAlgorithm::AreClustersAssoc
 
     if (m_clusterDirectionMap.end() == candIter)
     {
-        const LArVertexHelper::ClusterDirection direction((nullptr == pVertex) ? LArVertexHelper::DIRECTION_UNKNOWN
-                                                                               : LArVertexHelper::GetClusterDirectionInZ(this->GetPandora(), pVertex,
-                                                                                     pCluster, m_directionTanAngle, m_directionApexShift));
+        const LArVertexHelper::ClusterDirection direction((nullptr == pVertex)
+                ? LArVertexHelper::DIRECTION_UNKNOWN
+                : LArVertexHelper::GetClusterDirectionInZ(this->GetPandora(), pVertex, pCluster, m_directionTanAngle, m_directionApexShift));
         candIter = m_clusterDirectionMap.insert(ClusterDirectionMap::value_type(pCluster, direction)).first;
     }
 

--- a/larpandoracontent/LArTrackShowerId/TrackShowerIdFeatureTool.cc
+++ b/larpandoracontent/LArTrackShowerId/TrackShowerIdFeatureTool.cc
@@ -24,7 +24,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-TwoDShowerFitFeatureTool::TwoDShowerFitFeatureTool() : m_slidingShowerFitWindow(3), m_slidingLinearFitWindow(10000)
+TwoDShowerFitFeatureTool::TwoDShowerFitFeatureTool() :
+    m_slidingShowerFitWindow(3),
+    m_slidingLinearFitWindow(10000)
 {
 }
 
@@ -85,7 +87,9 @@ StatusCode TwoDShowerFitFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-TwoDLinearFitFeatureTool::TwoDLinearFitFeatureTool() : m_slidingLinearFitWindow(3), m_slidingLinearFitWindowLarge(10000)
+TwoDLinearFitFeatureTool::TwoDLinearFitFeatureTool() :
+    m_slidingLinearFitWindow(3),
+    m_slidingLinearFitWindowLarge(10000)
 {
 }
 
@@ -256,7 +260,8 @@ StatusCode TwoDLinearFitFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-TwoDVertexDistanceFeatureTool::TwoDVertexDistanceFeatureTool() : m_slidingLinearFitWindow(10000)
+TwoDVertexDistanceFeatureTool::TwoDVertexDistanceFeatureTool() :
+    m_slidingLinearFitWindow(10000)
 {
 }
 
@@ -395,7 +400,11 @@ StatusCode PfoHierarchyFeatureTool::ReadSettings(const TiXmlHandle /*xmlHandle*/
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 ConeChargeFeatureTool::ConeChargeFeatureTool() :
-    m_conMinHits(3), m_minCharge(0.1f), m_conFracRange(0.2f), m_MoliereRadius(10.1f), m_MoliereRadiusFrac(0.2f)
+    m_conMinHits(3),
+    m_minCharge(0.1f),
+    m_conFracRange(0.2f),
+    m_MoliereRadius(10.1f),
+    m_MoliereRadiusFrac(0.2f)
 {
 }
 
@@ -429,8 +438,8 @@ void ConeChargeFeatureTool::Run(
         concentration = (chargeCore + chargeHalo > std::numeric_limits<float>::epsilon()) ? chargeCon / (chargeCore + chargeHalo) : -1.f;
         const float pfoLength(std::sqrt(LArPfoHelper::GetThreeDLengthSquared(pInputPfo)));
         conicalness = (pfoLength > std::numeric_limits<float>::epsilon())
-                          ? this->CalculateConicalness(clusterCaloHitList, pfoStart, eigenVecs[0], pfoLength)
-                          : 1.f;
+            ? this->CalculateConicalness(clusterCaloHitList, pfoStart, eigenVecs[0], pfoLength)
+            : 1.f;
     }
 
     featureVector.push_back(haloTotalRatio);
@@ -535,7 +544,9 @@ StatusCode ConeChargeFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-ThreeDLinearFitFeatureTool::ThreeDLinearFitFeatureTool() : m_slidingLinearFitWindow(3), m_slidingLinearFitWindowLarge(10000)
+ThreeDLinearFitFeatureTool::ThreeDLinearFitFeatureTool() :
+    m_slidingLinearFitWindow(3),
+    m_slidingLinearFitWindowLarge(10000)
 {
 }
 
@@ -797,7 +808,9 @@ StatusCode ThreeDVertexDistanceFeatureTool::ReadSettings(const TiXmlHandle /*xml
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-ThreeDOpeningAngleFeatureTool::ThreeDOpeningAngleFeatureTool() : m_hitFraction(0.5f), m_defaultValue(0.1f)
+ThreeDOpeningAngleFeatureTool::ThreeDOpeningAngleFeatureTool() :
+    m_hitFraction(0.5f),
+    m_defaultValue(0.1f)
 {
 }
 
@@ -1050,7 +1063,8 @@ StatusCode ThreeDPCAFeatureTool::ReadSettings(const TiXmlHandle /*xmlHandle*/)
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-ThreeDChargeFeatureTool::ThreeDChargeFeatureTool() : m_endChargeFraction(0.1f)
+ThreeDChargeFeatureTool::ThreeDChargeFeatureTool() :
+    m_endChargeFraction(0.1f)
 {
 }
 
@@ -1195,7 +1209,8 @@ StatusCode ThreeDChargeFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-ThreeDChargeFeatureTool::VertexComparator::VertexComparator(const CartesianVector vertexPosition2D) : m_neutrinoVertex(vertexPosition2D)
+ThreeDChargeFeatureTool::VertexComparator::VertexComparator(const CartesianVector vertexPosition2D) :
+    m_neutrinoVertex(vertexPosition2D)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterAssociationAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterAssociationAlgorithm.cc
@@ -17,7 +17,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-ClusterAssociationAlgorithm::ClusterAssociationAlgorithm() : m_mergeMade(false), m_resolveAmbiguousAssociations(true)
+ClusterAssociationAlgorithm::ClusterAssociationAlgorithm() :
+    m_mergeMade(false),
+    m_resolveAmbiguousAssociations(true)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterExtensionAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterExtensionAlgorithm.h
@@ -119,7 +119,10 @@ protected:
 
 inline ClusterExtensionAlgorithm::ClusterAssociation::ClusterAssociation(
     const VertexType parent, const VertexType daughter, const AssociationType association, const float fom) :
-    m_parent(parent), m_daughter(daughter), m_association(association), m_fom(fom)
+    m_parent(parent),
+    m_daughter(daughter),
+    m_association(association),
+    m_fom(fom)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterGrowingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterGrowingAlgorithm.cc
@@ -17,7 +17,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-ClusterGrowingAlgorithm::ClusterGrowingAlgorithm() : m_maxClusterSeparation(2.5f)
+ClusterGrowingAlgorithm::ClusterGrowingAlgorithm() :
+    m_maxClusterSeparation(2.5f)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/CrossGapsAssociationAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/CrossGapsAssociationAlgorithm.cc
@@ -130,7 +130,7 @@ bool CrossGapsAssociationAlgorithm::AreClustersAssociated(const TwoDSlidingFitRe
         return false;
 
     return (this->IsAssociated(innerFitResult.GetGlobalMaxLayerPosition(), innerFitResult.GetGlobalMaxLayerDirection(), outerFitResult) &&
-            this->IsAssociated(outerFitResult.GetGlobalMinLayerPosition(), outerFitResult.GetGlobalMinLayerDirection() * -1.f, innerFitResult));
+        this->IsAssociated(outerFitResult.GetGlobalMinLayerPosition(), outerFitResult.GetGlobalMinLayerDirection() * -1.f, innerFitResult));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/CrossGapsExtensionAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/CrossGapsExtensionAlgorithm.cc
@@ -20,7 +20,11 @@ namespace lar_content
 {
 
 CrossGapsExtensionAlgorithm::CrossGapsExtensionAlgorithm() :
-    m_minClusterLength(5.f), m_minGapFraction(0.5f), m_maxGapTolerance(2.f), m_maxTransverseDisplacement(2.5f), m_maxRelativeAngle(10.f)
+    m_minClusterLength(5.f),
+    m_minGapFraction(0.5f),
+    m_maxGapTolerance(2.f),
+    m_maxTransverseDisplacement(2.5f),
+    m_maxRelativeAngle(10.f)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/LongitudinalAssociationAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/LongitudinalAssociationAlgorithm.cc
@@ -158,10 +158,10 @@ bool LongitudinalAssociationAlgorithm::AreClustersAssociated(const CartesianVect
     const CartesianVector innerEndFit2(
         outerFit.GetIntercept() + outerFit.GetDirection() * (outerFit.GetDirection().GetDotProduct(innerClusterEnd - outerFit.GetIntercept())));
 
-    const CartesianVector outerStartFit1(
-        outerFit.GetIntercept() + outerFit.GetDirection() * (outerFit.GetDirection().GetDotProduct(outerClusterStart - outerFit.GetIntercept())));
-    const CartesianVector outerStartFit2(
-        innerFit.GetIntercept() + innerFit.GetDirection() * (innerFit.GetDirection().GetDotProduct(outerClusterStart - innerFit.GetIntercept())));
+    const CartesianVector outerStartFit1(outerFit.GetIntercept() +
+        outerFit.GetDirection() * (outerFit.GetDirection().GetDotProduct(outerClusterStart - outerFit.GetIntercept())));
+    const CartesianVector outerStartFit2(innerFit.GetIntercept() +
+        innerFit.GetDirection() * (innerFit.GetDirection().GetDotProduct(outerClusterStart - innerFit.GetIntercept())));
 
     const CartesianVector clusterSeparation(outerClusterStart - innerClusterEnd);
 

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/SimpleClusterGrowingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/SimpleClusterGrowingAlgorithm.cc
@@ -17,7 +17,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-SimpleClusterGrowingAlgorithm::SimpleClusterGrowingAlgorithm() : m_minCaloHitsPerCluster(5)
+SimpleClusterGrowingAlgorithm::SimpleClusterGrowingAlgorithm() :
+    m_minCaloHitsPerCluster(5)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/SimpleClusterMergingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/SimpleClusterMergingAlgorithm.cc
@@ -17,7 +17,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-SimpleClusterMergingAlgorithm::SimpleClusterMergingAlgorithm() : m_minCaloHitsPerCluster(5), m_maxClusterSeparation(2.5f)
+SimpleClusterMergingAlgorithm::SimpleClusterMergingAlgorithm() :
+    m_minCaloHitsPerCluster(5),
+    m_maxClusterSeparation(2.5f)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/TransverseExtensionAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/TransverseExtensionAlgorithm.cc
@@ -20,7 +20,9 @@ namespace lar_content
 {
 
 TransverseExtensionAlgorithm::TransverseExtensionAlgorithm() :
-    m_minClusterLength(5.f), m_maxLongitudinalDisplacement(10.f), m_maxTransverseDisplacement(1.f)
+    m_minClusterLength(5.f),
+    m_maxLongitudinalDisplacement(10.f),
+    m_maxTransverseDisplacement(1.f)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterCreation/ClusteringParentAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterCreation/ClusteringParentAlgorithm.cc
@@ -15,7 +15,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-ClusteringParentAlgorithm::ClusteringParentAlgorithm() : m_replaceCurrentCaloHitList(false), m_replaceCurrentClusterList(true)
+ClusteringParentAlgorithm::ClusteringParentAlgorithm() :
+    m_replaceCurrentCaloHitList(false),
+    m_replaceCurrentClusterList(true)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterCreation/SimpleClusterCreationAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterCreation/SimpleClusterCreationAlgorithm.cc
@@ -17,7 +17,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-SimpleClusterCreationAlgorithm::SimpleClusterCreationAlgorithm() : m_clusteringWindowSquared(1.f)
+SimpleClusterCreationAlgorithm::SimpleClusterCreationAlgorithm() :
+    m_clusteringWindowSquared(1.f)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterMopUp/BoundedClusterMopUpAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterMopUp/BoundedClusterMopUpAlgorithm.cc
@@ -19,7 +19,9 @@ namespace lar_content
 {
 
 BoundedClusterMopUpAlgorithm::BoundedClusterMopUpAlgorithm() :
-    m_slidingFitWindow(20), m_showerEdgeMultiplier(1.5f), m_minBoundedFraction(0.5f)
+    m_slidingFitWindow(20),
+    m_showerEdgeMultiplier(1.5f),
+    m_minBoundedFraction(0.5f)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterMopUp/ClusterMopUpBaseAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterMopUp/ClusterMopUpBaseAlgorithm.cc
@@ -18,7 +18,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-ClusterMopUpBaseAlgorithm::ClusterMopUpBaseAlgorithm() : m_excludePfosContainingTracks(true)
+ClusterMopUpBaseAlgorithm::ClusterMopUpBaseAlgorithm() :
+    m_excludePfosContainingTracks(true)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterMopUp/ConeClusterMopUpAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterMopUp/ConeClusterMopUpAlgorithm.cc
@@ -21,7 +21,11 @@ namespace lar_content
 {
 
 ConeClusterMopUpAlgorithm::ConeClusterMopUpAlgorithm() :
-    m_slidingFitWindow(20), m_showerEdgeMultiplier(1.5f), m_coneAngleCentile(0.85f), m_maxConeLengthMultiplier(1.5f), m_minBoundedFraction(0.5f)
+    m_slidingFitWindow(20),
+    m_showerEdgeMultiplier(1.5f),
+    m_coneAngleCentile(0.85f),
+    m_maxConeLengthMultiplier(1.5f),
+    m_minBoundedFraction(0.5f)
 {
 }
 
@@ -67,7 +71,7 @@ void ConeClusterMopUpAlgorithm::ClusterMopUp(const ClusterList &pfoClusters, con
             const HitType hitType(LArClusterHelper::GetClusterHitType(pPfoCluster));
             const CartesianVector vertexPosition2D(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), hitType));
             const bool vertexAtMinL((vertexPosition2D - minLayerPositionOnAxis).GetMagnitudeSquared() <
-                                    (vertexPosition2D - maxLayerPositionOnAxis).GetMagnitudeSquared());
+                (vertexPosition2D - maxLayerPositionOnAxis).GetMagnitudeSquared());
 
             // Cone edges
             CoordinateList coordinateListP, coordinateListN;
@@ -92,13 +96,13 @@ void ConeClusterMopUpAlgorithm::ClusterMopUp(const ClusterList &pfoClusters, con
 
             const Coordinate maxP(coordinateListP.at(m_coneAngleCentile * coordinateListP.size()));
             const Coordinate minP(vertexAtMinL
-                                      ? Coordinate(layerFitResultMapP.begin()->second.GetL(), layerFitResultMapP.begin()->second.GetFitT())
-                                      : Coordinate(layerFitResultMapP.rbegin()->second.GetL(), layerFitResultMapP.rbegin()->second.GetFitT()));
+                    ? Coordinate(layerFitResultMapP.begin()->second.GetL(), layerFitResultMapP.begin()->second.GetFitT())
+                    : Coordinate(layerFitResultMapP.rbegin()->second.GetL(), layerFitResultMapP.rbegin()->second.GetFitT()));
 
             const Coordinate maxN(coordinateListN.at((1.f - m_coneAngleCentile) * coordinateListN.size()));
             const Coordinate minN(vertexAtMinL
-                                      ? Coordinate(layerFitResultMapN.begin()->second.GetL(), layerFitResultMapN.begin()->second.GetFitT())
-                                      : Coordinate(layerFitResultMapN.rbegin()->second.GetL(), layerFitResultMapN.rbegin()->second.GetFitT()));
+                    ? Coordinate(layerFitResultMapN.begin()->second.GetL(), layerFitResultMapN.begin()->second.GetFitT())
+                    : Coordinate(layerFitResultMapN.rbegin()->second.GetL(), layerFitResultMapN.rbegin()->second.GetFitT()));
 
             const float minL(layerFitResultMapS.begin()->second.GetL());
             const float maxL(minL + m_maxConeLengthMultiplier * std::fabs(layerFitResultMapS.rbegin()->second.GetL() - minL));

--- a/larpandoracontent/LArTwoDReco/LArClusterMopUp/IsolatedClusterMopUpAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterMopUp/IsolatedClusterMopUpAlgorithm.cc
@@ -21,7 +21,9 @@ namespace lar_content
 {
 
 IsolatedClusterMopUpAlgorithm::IsolatedClusterMopUpAlgorithm() :
-    m_maxCaloHitsInCluster(20), m_maxHitClusterDistance(5.f), m_addHitsAsIsolated(true)
+    m_maxCaloHitsInCluster(20),
+    m_maxHitClusterDistance(5.f),
+    m_addHitsAsIsolated(true)
 {
     // ATTN Default value differs from base class
     m_excludePfosContainingTracks = false;

--- a/larpandoracontent/LArTwoDReco/LArClusterMopUp/NearbyClusterMopUpAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterMopUp/NearbyClusterMopUpAlgorithm.cc
@@ -19,7 +19,10 @@ namespace lar_content
 {
 
 NearbyClusterMopUpAlgorithm::NearbyClusterMopUpAlgorithm() :
-    m_minHitsInCluster(5), m_vertexProximity(5.f), m_minClusterSeparation(2.5f), m_touchingDistance(0.001f)
+    m_minHitsInCluster(5),
+    m_vertexProximity(5.f),
+    m_minClusterSeparation(2.5f),
+    m_touchingDistance(0.001f)
 {
 }
 
@@ -58,8 +61,7 @@ void NearbyClusterMopUpAlgorithm::ClusterMopUp(const ClusterList &pfoClusters, c
             const float outerRV((vertexPosition2D - pClusterR->GetCentroid(pClusterR->GetOuterPseudoLayer())).GetMagnitude());
 
             // ATTN Could use pointing clusters here, for consistency with other vertex association mechanics
-            if (pVertex && (((innerPV < m_vertexProximity) || (outerPV < m_vertexProximity)) &&
-                               ((innerRV < m_vertexProximity) || (outerRV < m_vertexProximity))))
+            if (pVertex && (((innerPV < m_vertexProximity) || (outerPV < m_vertexProximity)) && ((innerRV < m_vertexProximity) || (outerRV < m_vertexProximity))))
                 continue;
 
             const float innerRP(LArClusterHelper::GetClosestDistance(pClusterR->GetCentroid(pClusterR->GetInnerPseudoLayer()), pClusterP));

--- a/larpandoracontent/LArTwoDReco/LArClusterMopUp/SlidingConeClusterMopUpAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterMopUp/SlidingConeClusterMopUpAlgorithm.cc
@@ -165,9 +165,9 @@ void SlidingConeClusterMopUpAlgorithm::GetClusterMergeMap(const Vertex *const pV
 
             const float vertexToMinLayer(!pVertex ? 0.f : (pVertex->GetPosition() - minLayerPosition).GetMagnitude());
             const float vertexToMaxLayer(!pVertex ? 0.f : (pVertex->GetPosition() - maxLayerPosition).GetMagnitude());
-            const ConeSelection coneSelection(!pVertex                                ? CONE_BOTH_DIRECTIONS
-                                              : (vertexToMaxLayer > vertexToMinLayer) ? CONE_FORWARD_ONLY
-                                                                                      : CONE_BACKWARD_ONLY);
+            const ConeSelection coneSelection(!pVertex      ? CONE_BOTH_DIRECTIONS
+                    : (vertexToMaxLayer > vertexToMinLayer) ? CONE_FORWARD_ONLY
+                                                            : CONE_BACKWARD_ONLY);
 
             slidingConeFitResult3D.GetSimpleConeList(m_nConeFitLayers, m_nConeFits, coneSelection, simpleConeList3D);
         }

--- a/larpandoracontent/LArTwoDReco/LArClusterMopUp/SlidingConeClusterMopUpAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterMopUp/SlidingConeClusterMopUpAlgorithm.h
@@ -148,7 +148,9 @@ private:
 
 inline SlidingConeClusterMopUpAlgorithm::ClusterMerge::ClusterMerge(
     const pandora::Cluster *const pParentCluster, const float boundedFraction, const float meanRT) :
-    m_pParentCluster(pParentCluster), m_boundedFraction(boundedFraction), m_meanRT(meanRT)
+    m_pParentCluster(pParentCluster),
+    m_boundedFraction(boundedFraction),
+    m_meanRT(meanRT)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/DeltaRaySplittingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/DeltaRaySplittingAlgorithm.cc
@@ -18,7 +18,10 @@ namespace lar_content
 {
 
 DeltaRaySplittingAlgorithm::DeltaRaySplittingAlgorithm() :
-    m_stepSize(1.f), m_maxTransverseDisplacement(1.5f), m_maxLongitudinalDisplacement(10.f), m_minCosRelativeAngle(0.985f)
+    m_stepSize(1.f),
+    m_maxTransverseDisplacement(1.5f),
+    m_maxLongitudinalDisplacement(10.f),
+    m_minCosRelativeAngle(0.985f)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/KinkSplittingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/KinkSplittingAlgorithm.cc
@@ -15,7 +15,10 @@ using namespace pandora;
 namespace lar_content
 {
 
-KinkSplittingAlgorithm::KinkSplittingAlgorithm() : m_maxScatterRms(0.2f), m_maxScatterCosTheta(0.905f), m_maxSlidingCosTheta(0.985f)
+KinkSplittingAlgorithm::KinkSplittingAlgorithm() :
+    m_maxScatterRms(0.2f),
+    m_maxScatterCosTheta(0.905f),
+    m_maxSlidingCosTheta(0.985f)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/LayerSplittingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/LayerSplittingAlgorithm.cc
@@ -16,7 +16,11 @@ namespace lar_content
 {
 
 LayerSplittingAlgorithm::LayerSplittingAlgorithm() :
-    m_minClusterLayers(20), m_layerWindow(10), m_maxScatterRms(0.35f), m_maxScatterCosTheta(0.5f), m_maxSlidingCosTheta(0.866f)
+    m_minClusterLayers(20),
+    m_layerWindow(10),
+    m_maxScatterRms(0.35f),
+    m_maxScatterCosTheta(0.5f),
+    m_maxSlidingCosTheta(0.866f)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/TrackConsolidationAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/TrackConsolidationAlgorithm.cc
@@ -18,7 +18,9 @@ namespace lar_content
 {
 
 TrackConsolidationAlgorithm::TrackConsolidationAlgorithm() :
-    m_maxTransverseDisplacement(1.f), m_minAssociatedSpan(1.f), m_minAssociatedFraction(0.5f)
+    m_maxTransverseDisplacement(1.f),
+    m_minAssociatedSpan(1.f),
+    m_minAssociatedFraction(0.5f)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitConsolidationAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitConsolidationAlgorithm.cc
@@ -19,7 +19,9 @@ namespace lar_content
 {
 
 TwoDSlidingFitConsolidationAlgorithm::TwoDSlidingFitConsolidationAlgorithm() :
-    m_minTrackLength(7.5f), m_maxClusterLength(15.f), m_halfWindowLayers(25)
+    m_minTrackLength(7.5f),
+    m_maxClusterLength(15.f),
+    m_halfWindowLayers(25)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitMultiSplitAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitMultiSplitAlgorithm.cc
@@ -18,7 +18,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-TwoDSlidingFitMultiSplitAlgorithm::TwoDSlidingFitMultiSplitAlgorithm() : m_slidingFitHalfWindow(15), m_inputClusterList("")
+TwoDSlidingFitMultiSplitAlgorithm::TwoDSlidingFitMultiSplitAlgorithm() :
+    m_slidingFitHalfWindow(15),
+    m_inputClusterList("")
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitSplittingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitSplittingAlgorithm.cc
@@ -18,7 +18,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-TwoDSlidingFitSplittingAlgorithm::TwoDSlidingFitSplittingAlgorithm() : m_slidingFitHalfWindow(20), m_minClusterLength(10.f)
+TwoDSlidingFitSplittingAlgorithm::TwoDSlidingFitSplittingAlgorithm() :
+    m_slidingFitHalfWindow(20),
+    m_minClusterLength(10.f)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitSplittingAndSplicingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitSplittingAndSplicingAlgorithm.cc
@@ -19,7 +19,11 @@ namespace lar_content
 {
 
 TwoDSlidingFitSplittingAndSplicingAlgorithm::TwoDSlidingFitSplittingAndSplicingAlgorithm() :
-    m_shortHalfWindowLayers(10), m_longHalfWindowLayers(20), m_minClusterLength(7.5f), m_vetoDisplacement(1.5f), m_runCosmicMode(false)
+    m_shortHalfWindowLayers(10),
+    m_longHalfWindowLayers(20),
+    m_minClusterLength(7.5f),
+    m_vetoDisplacement(1.5f),
+    m_runCosmicMode(false)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitSplittingAndSwitchingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitSplittingAndSwitchingAlgorithm.cc
@@ -19,7 +19,8 @@ namespace lar_content
 {
 
 TwoDSlidingFitSplittingAndSwitchingAlgorithm::TwoDSlidingFitSplittingAndSwitchingAlgorithm() :
-    m_halfWindowLayers(25), m_minClusterLength(10.f)
+    m_halfWindowLayers(25),
+    m_minClusterLength(10.f)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/VertexSplittingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/VertexSplittingAlgorithm.cc
@@ -18,7 +18,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-VertexSplittingAlgorithm::VertexSplittingAlgorithm() : m_splitDisplacementSquared(4.f * 4.f), m_vertexDisplacementSquared(1.f * 1.f)
+VertexSplittingAlgorithm::VertexSplittingAlgorithm() :
+    m_splitDisplacementSquared(4.f * 4.f),
+    m_vertexDisplacementSquared(1.f * 1.f)
 {
     // ATTN Some default values differ from base class
     m_minClusterLength = 1.f;

--- a/larpandoracontent/LArTwoDReco/LArCosmicRay/ClusterAssociation.h
+++ b/larpandoracontent/LArTwoDReco/LArCosmicRay/ClusterAssociation.h
@@ -177,9 +177,9 @@ inline ClusterAssociation::ClusterAssociation(const pandora::CartesianVector &up
 inline bool ClusterAssociation::operator==(const ClusterAssociation &clusterAssociation) const
 {
     return (m_upstreamMergePoint == clusterAssociation.GetUpstreamMergePoint() &&
-            m_upstreamMergeDirection == clusterAssociation.GetUpstreamMergeDirection() &&
-            m_downstreamMergePoint == clusterAssociation.GetDownstreamMergePoint() &&
-            m_downstreamMergeDirection == clusterAssociation.GetDownstreamMergeDirection());
+        m_upstreamMergeDirection == clusterAssociation.GetUpstreamMergeDirection() &&
+        m_downstreamMergePoint == clusterAssociation.GetDownstreamMergePoint() &&
+        m_downstreamMergeDirection == clusterAssociation.GetDownstreamMergeDirection());
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -263,7 +263,10 @@ inline ClusterPairAssociation::ClusterPairAssociation(const pandora::CartesianVe
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline ClusterPairAssociation::ClusterPairAssociation() : ClusterAssociation(), m_pUpstreamCluster(nullptr), m_pDownstreamCluster(nullptr)
+inline ClusterPairAssociation::ClusterPairAssociation() :
+    ClusterAssociation(),
+    m_pUpstreamCluster(nullptr),
+    m_pDownstreamCluster(nullptr)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArCosmicRay/CosmicRaySplittingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArCosmicRay/CosmicRaySplittingAlgorithm.cc
@@ -94,8 +94,9 @@ StatusCode CosmicRaySplittingAlgorithm::Run()
             float lengthSquared1(std::numeric_limits<float>::max());
             float lengthSquared2(std::numeric_limits<float>::max());
 
-            if (STATUS_CODE_SUCCESS != this->ConfirmSplitPosition(branchSlidingFitResult, replacementSlidingFitResult, splitPosition,
-                                           splitDirection1, splitDirection2, lengthSquared1, lengthSquared2))
+            if (STATUS_CODE_SUCCESS !=
+                this->ConfirmSplitPosition(branchSlidingFitResult, replacementSlidingFitResult, splitPosition, splitDirection1,
+                    splitDirection2, lengthSquared1, lengthSquared2))
                 continue;
 
             if (lengthSquared1 < bestLengthSquared1)

--- a/larpandoracontent/LArTwoDReco/LArCosmicRay/DeltaRayExtensionAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArCosmicRay/DeltaRayExtensionAlgorithm.cc
@@ -18,7 +18,10 @@ namespace lar_content
 {
 
 DeltaRayExtensionAlgorithm::DeltaRayExtensionAlgorithm() :
-    m_minClusterLength(1.f), m_maxClusterLength(10.f), m_maxLongitudinalDisplacement(2.5f), m_maxTransverseDisplacement(1.5f)
+    m_minClusterLength(1.f),
+    m_maxClusterLength(10.f),
+    m_maxLongitudinalDisplacement(2.5f),
+    m_maxTransverseDisplacement(1.5f)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArCosmicRay/DeltaRayGrowingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArCosmicRay/DeltaRayGrowingAlgorithm.cc
@@ -19,7 +19,10 @@ namespace lar_content
 {
 
 DeltaRayGrowingAlgorithm::DeltaRayGrowingAlgorithm() :
-    m_minCaloHitsPerCluster(2), m_minSeedClusterCaloHits(5), m_maxSeedClusterLength(10.f), m_maxSeedClusterDisplacement(1.5f)
+    m_minCaloHitsPerCluster(2),
+    m_minSeedClusterCaloHits(5),
+    m_maxSeedClusterLength(10.f),
+    m_maxSeedClusterDisplacement(1.5f)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArCosmicRay/TrackRefinementBaseAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArCosmicRay/TrackRefinementBaseAlgorithm.cc
@@ -531,7 +531,7 @@ const Cluster *TrackRefinementBaseAlgorithm::RemoveOffAxisHitsFromTrack(const Cl
 
             if (extrapolatedCaloHitIter != clusterToCaloHitListMap.end())
                 isAnExtrapolatedHit = std::find(extrapolatedCaloHitIter->second.begin(), extrapolatedCaloHitIter->second.end(), pCaloHit) !=
-                                      extrapolatedCaloHitIter->second.end();
+                    extrapolatedCaloHitIter->second.end();
 
             const bool isAbove(((clusterGradient * hitPosition.GetX()) + clusterIntercept) < (isVertical ? hitPosition.GetX() : hitPosition.GetZ()));
             const bool isToRemove(!isAnExtrapolatedHit && (((thisL < rL) && isEndUpstream) || ((thisL > rL) && !isEndUpstream)));
@@ -594,9 +594,9 @@ void TrackRefinementBaseAlgorithm::AddHitsToMainTrack(const Cluster *const pMain
     const bool isVertical(std::fabs(clusterAssociation.GetConnectingLineDirection().GetX()) < std::numeric_limits<float>::epsilon());
     const float connectingLineGradient(
         isVertical ? 0.f : clusterAssociation.GetConnectingLineDirection().GetZ() / clusterAssociation.GetConnectingLineDirection().GetX());
-    const float connectingLineIntercept(isVertical ? clusterAssociation.GetUpstreamMergePoint().GetX()
-                                                   : clusterAssociation.GetUpstreamMergePoint().GetZ() -
-                                                         (connectingLineGradient * clusterAssociation.GetUpstreamMergePoint().GetX()));
+    const float connectingLineIntercept(isVertical
+            ? clusterAssociation.GetUpstreamMergePoint().GetX()
+            : clusterAssociation.GetUpstreamMergePoint().GetZ() - (connectingLineGradient * clusterAssociation.GetUpstreamMergePoint().GetX()));
 
     const OrderedCaloHitList orderedCaloHitList(pShowerCluster->GetOrderedCaloHitList());
     for (const OrderedCaloHitList::value_type &mapEntry : orderedCaloHitList)
@@ -613,7 +613,7 @@ void TrackRefinementBaseAlgorithm::AddHitsToMainTrack(const Cluster *const pMain
             {
                 const CartesianVector &hitPosition(pCaloHit->GetPositionVector());
                 const bool isAbove(((connectingLineGradient * hitPosition.GetX()) + connectingLineIntercept) <
-                                   (isVertical ? hitPosition.GetX() : hitPosition.GetZ()));
+                    (isVertical ? hitPosition.GetX() : hitPosition.GetZ()));
                 const Cluster *&pClusterToModify(isAbove ? pAboveCluster : pBelowCluster);
 
                 if (pClusterToModify)

--- a/larpandoracontent/LArTwoDReco/LArCosmicRay/TrackRefinementBaseAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArCosmicRay/TrackRefinementBaseAlgorithm.h
@@ -322,7 +322,9 @@ protected:
 
 inline TrackRefinementBaseAlgorithm::SortByDistanceAlongLine::SortByDistanceAlongLine(
     const pandora::CartesianVector &startPoint, const pandora::CartesianVector &lineDirection, const bool hitWidthMode) :
-    m_startPoint(startPoint), m_lineDirection(lineDirection.GetUnitVector()), m_hitWidthMode(hitWidthMode)
+    m_startPoint(startPoint),
+    m_lineDirection(lineDirection.GetUnitVector()),
+    m_hitWidthMode(hitWidthMode)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/StreamSelectionAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/StreamSelectionAlgorithm.cc
@@ -22,7 +22,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-StreamSelectionAlgorithm::StreamSelectionAlgorithm() : m_inputListName{""}, m_listType{"cluster"}
+StreamSelectionAlgorithm::StreamSelectionAlgorithm() :
+    m_inputListName{""},
+    m_listType{"cluster"}
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/TwoDParticleCreationAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/TwoDParticleCreationAlgorithm.cc
@@ -15,7 +15,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-TwoDParticleCreationAlgorithm::TwoDParticleCreationAlgorithm() : m_minHitsInCluster(5), m_minClusterEnergy(0.f)
+TwoDParticleCreationAlgorithm::TwoDParticleCreationAlgorithm() :
+    m_minHitsInCluster(5),
+    m_minClusterEnergy(0.f)
 {
 }
 

--- a/larpandoracontent/LArUtility/KDTreeLinkerAlgoT.h
+++ b/larpandoracontent/LArUtility/KDTreeLinkerAlgoT.h
@@ -160,7 +160,12 @@ private:
 
 template <typename DATA, unsigned DIM>
 inline KDTreeLinkerAlgo<DATA, DIM>::KDTreeLinkerAlgo() :
-    root_(nullptr), nodePool_(nullptr), nodePoolSize_(-1), nodePoolPos_(-1), closestNeighbour(nullptr), initialEltList(nullptr)
+    root_(nullptr),
+    nodePool_(nullptr),
+    nodePoolSize_(-1),
+    nodePoolPos_(-1),
+    closestNeighbour(nullptr),
+    initialEltList(nullptr)
 {
 }
 

--- a/larpandoracontent/LArUtility/KDTreeLinkerToolsT.h
+++ b/larpandoracontent/LArUtility/KDTreeLinkerToolsT.h
@@ -246,7 +246,8 @@ inline KDTreeBoxT<DIM>::KDTreeBoxT(Ts... dimargs)
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename DATA, unsigned DIM>
-inline KDTreeNodeInfoT<DATA, DIM>::KDTreeNodeInfoT() : data()
+inline KDTreeNodeInfoT<DATA, DIM>::KDTreeNodeInfoT() :
+    data()
 {
 }
 
@@ -254,7 +255,9 @@ inline KDTreeNodeInfoT<DATA, DIM>::KDTreeNodeInfoT() : data()
 
 template <typename DATA, unsigned DIM>
 template <typename... Ts>
-inline KDTreeNodeInfoT<DATA, DIM>::KDTreeNodeInfoT(const DATA &d, Ts... dimargs) : data(d), dims{{dimargs...}}
+inline KDTreeNodeInfoT<DATA, DIM>::KDTreeNodeInfoT(const DATA &d, Ts... dimargs) :
+    data(d),
+    dims{{dimargs...}}
 {
 }
 
@@ -262,7 +265,9 @@ inline KDTreeNodeInfoT<DATA, DIM>::KDTreeNodeInfoT(const DATA &d, Ts... dimargs)
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename DATA, unsigned DIM>
-inline KDTreeNodeT<DATA, DIM>::KDTreeNodeT() : left(nullptr), right(nullptr)
+inline KDTreeNodeT<DATA, DIM>::KDTreeNodeT() :
+    left(nullptr),
+    right(nullptr)
 {
 }
 

--- a/larpandoracontent/LArUtility/ListPruningAlgorithm.cc
+++ b/larpandoracontent/LArUtility/ListPruningAlgorithm.cc
@@ -15,7 +15,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-ListPruningAlgorithm::ListPruningAlgorithm() : m_warnIfObjectsUnavailable(true)
+ListPruningAlgorithm::ListPruningAlgorithm() :
+    m_warnIfObjectsUnavailable(true)
 {
 }
 

--- a/larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.cc
+++ b/larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.cc
@@ -16,7 +16,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-AsymmetryFeatureBaseTool::AsymmetryFeatureBaseTool() : m_maxAsymmetryDistance(5.f)
+AsymmetryFeatureBaseTool::AsymmetryFeatureBaseTool() :
+    m_maxAsymmetryDistance(5.f)
 {
 }
 

--- a/larpandoracontent/LArVertex/CandidateVertexCreationAlgorithm.cc
+++ b/larpandoracontent/LArVertex/CandidateVertexCreationAlgorithm.cc
@@ -109,9 +109,9 @@ void CandidateVertexCreationAlgorithm::SelectClusters(ClusterVector &clusterVect
         if ((TPC_VIEW_U != hitType) && (TPC_VIEW_V != hitType) && (TPC_VIEW_W != hitType))
             throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
-        ClusterVector &selectedClusterVector((TPC_VIEW_U == hitType)   ? clusterVectorU
-                                             : (TPC_VIEW_V == hitType) ? clusterVectorV
-                                                                       : clusterVectorW);
+        ClusterVector &selectedClusterVector((TPC_VIEW_U == hitType) ? clusterVectorU
+                : (TPC_VIEW_V == hitType)                            ? clusterVectorV
+                                                                     : clusterVectorW);
 
         if (!selectedClusterVector.empty())
             throw StatusCodeException(STATUS_CODE_FAILURE);
@@ -146,8 +146,7 @@ void CandidateVertexCreationAlgorithm::SelectClusters(ClusterVector &clusterVect
             if (pCluster->GetParticleId() == E_MINUS && m_reducedCandidates)
             {
                 selectionCutFactor = (m_selectionCutFactorMax + 1.f) * 0.5f +
-                                     (m_selectionCutFactorMax - 1.f) * 0.5f *
-                                         std::tanh(static_cast<float>(nClustersPassingMaxCuts) - m_nClustersPassingMaxCutsPar);
+                    (m_selectionCutFactorMax - 1.f) * 0.5f * std::tanh(static_cast<float>(nClustersPassingMaxCuts) - m_nClustersPassingMaxCutsPar);
             }
 
             if (pCluster->GetNCaloHits() < m_minClusterCaloHits * selectionCutFactor)

--- a/larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.cc
+++ b/larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.cc
@@ -16,7 +16,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-EnergyDepositionAsymmetryFeatureTool::EnergyDepositionAsymmetryFeatureTool() : GlobalAsymmetryFeatureTool()
+EnergyDepositionAsymmetryFeatureTool::EnergyDepositionAsymmetryFeatureTool() :
+    GlobalAsymmetryFeatureTool()
 {
 }
 

--- a/larpandoracontent/LArVertex/EnergyKickFeatureTool.cc
+++ b/larpandoracontent/LArVertex/EnergyKickFeatureTool.cc
@@ -17,7 +17,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-EnergyKickFeatureTool::EnergyKickFeatureTool() : m_rOffset(10.f), m_xOffset(0.06f)
+EnergyKickFeatureTool::EnergyKickFeatureTool() :
+    m_rOffset(10.f),
+    m_xOffset(0.06f)
 {
 }
 

--- a/larpandoracontent/LArVertex/EnergyKickVertexSelectionAlgorithm.cc
+++ b/larpandoracontent/LArVertex/EnergyKickVertexSelectionAlgorithm.cc
@@ -20,7 +20,10 @@ namespace lar_content
 {
 
 EnergyKickVertexSelectionAlgorithm::EnergyKickVertexSelectionAlgorithm() :
-    m_minClusterCaloHits(12), m_slidingFitWindow(100), m_epsilon(0.06), m_asymmetryConstant(3.f)
+    m_minClusterCaloHits(12),
+    m_slidingFitWindow(100),
+    m_epsilon(0.06),
+    m_asymmetryConstant(3.f)
 {
 }
 

--- a/larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.cc
+++ b/larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.cc
@@ -16,7 +16,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-GlobalAsymmetryFeatureTool::GlobalAsymmetryFeatureTool() : AsymmetryFeatureBaseTool()
+GlobalAsymmetryFeatureTool::GlobalAsymmetryFeatureTool() :
+    AsymmetryFeatureBaseTool()
 {
 }
 

--- a/larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.cc
+++ b/larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.cc
@@ -18,7 +18,9 @@ namespace lar_content
 {
 
 LocalAsymmetryFeatureTool::LocalAsymmetryFeatureTool() :
-    AsymmetryFeatureBaseTool(), m_minAsymmetryCosAngle(0.9962), m_maxAsymmetryNClusters(2)
+    AsymmetryFeatureBaseTool(),
+    m_minAsymmetryCosAngle(0.9962),
+    m_maxAsymmetryNClusters(2)
 {
 }
 

--- a/larpandoracontent/LArVertex/MvaVertexSelectionAlgorithm.cc
+++ b/larpandoracontent/LArVertex/MvaVertexSelectionAlgorithm.cc
@@ -34,7 +34,8 @@ namespace lar_content
 
 template <typename T>
 MvaVertexSelectionAlgorithm<T>::MvaVertexSelectionAlgorithm() :
-    TrainedVertexSelectionAlgorithm(), m_filePathEnvironmentVariable("FW_SEARCH_PATH")
+    TrainedVertexSelectionAlgorithm(),
+    m_filePathEnvironmentVariable("FW_SEARCH_PATH")
 {
 }
 

--- a/larpandoracontent/LArVertex/RPhiFeatureTool.h
+++ b/larpandoracontent/LArVertex/RPhiFeatureTool.h
@@ -180,7 +180,8 @@ private:
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline RPhiFeatureTool::KernelEstimate::KernelEstimate(const float sigma) : m_sigma(sigma)
+inline RPhiFeatureTool::KernelEstimate::KernelEstimate(const float sigma) :
+    m_sigma(sigma)
 {
     if (m_sigma < std::numeric_limits<float>::epsilon())
         throw pandora::StatusCodeException(pandora::STATUS_CODE_INVALID_PARAMETER);

--- a/larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.cc
+++ b/larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.cc
@@ -16,7 +16,9 @@ using namespace pandora;
 namespace lar_content
 {
 
-ShowerAsymmetryFeatureTool::ShowerAsymmetryFeatureTool() : AsymmetryFeatureBaseTool(), m_vertexClusterDistance(4.f)
+ShowerAsymmetryFeatureTool::ShowerAsymmetryFeatureTool() :
+    AsymmetryFeatureBaseTool(),
+    m_vertexClusterDistance(4.f)
 {
 }
 

--- a/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.h
+++ b/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.h
@@ -514,7 +514,8 @@ inline TrainedVertexSelectionAlgorithm::EventFeatureInfo::EventFeatureInfo(const
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline TrainedVertexSelectionAlgorithm::VertexSharedFeatureInfo::VertexSharedFeatureInfo(const float separation, const float axisHits) :
-    m_separation(separation), m_axisHits(axisHits)
+    m_separation(separation),
+    m_axisHits(axisHits)
 {
 }
 

--- a/larpandoracontent/LArVertex/VertexRefinementAlgorithm.cc
+++ b/larpandoracontent/LArVertex/VertexRefinementAlgorithm.cc
@@ -22,7 +22,10 @@ namespace lar_content
 {
 
 VertexRefinementAlgorithm::VertexRefinementAlgorithm() :
-    m_chiSquaredCut(2.f), m_distanceCut(5.f), m_minimumHitsCut(5), m_twoDDistanceCut(10.f)
+    m_chiSquaredCut(2.f),
+    m_distanceCut(5.f),
+    m_minimumHitsCut(5),
+    m_twoDDistanceCut(10.f)
 {
 }
 

--- a/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.h
+++ b/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.h
@@ -433,7 +433,8 @@ inline bool VertexSelectionBaseAlgorithm::IsBeamModeOn() const
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline VertexSelectionBaseAlgorithm::VertexScore::VertexScore(const pandora::Vertex *const pVertex, const float score) :
-    m_pVertex(pVertex), m_score(score)
+    m_pVertex(pVertex),
+    m_score(score)
 {
 }
 

--- a/larpandoradlcontent/LArMonitoring/DlHitValidationAlgorithm.cc
+++ b/larpandoradlcontent/LArMonitoring/DlHitValidationAlgorithm.cc
@@ -21,7 +21,10 @@ using namespace lar_content;
 namespace lar_dl_content
 {
 
-DlHitValidationAlgorithm::DlHitValidationAlgorithm() : m_confusionU(), m_confusionV(), m_confusionW()
+DlHitValidationAlgorithm::DlHitValidationAlgorithm() :
+    m_confusionU(),
+    m_confusionV(),
+    m_confusionW()
 {
 }
 

--- a/larpandoradlcontent/LArTrackShowerId/DlHitTrackShowerIdAlgorithm.cc
+++ b/larpandoradlcontent/LArTrackShowerId/DlHitTrackShowerIdAlgorithm.cc
@@ -30,7 +30,12 @@ namespace lar_dl_content
 {
 
 DlHitTrackShowerIdAlgorithm::DlHitTrackShowerIdAlgorithm() :
-    m_imageHeight(256), m_imageWidth(256), m_tileSize(128.f), m_visualize(false), m_useTrainingMode(false), m_trainingOutputFile("")
+    m_imageHeight(256),
+    m_imageWidth(256),
+    m_tileSize(128.f),
+    m_visualize(false),
+    m_useTrainingMode(false),
+    m_trainingOutputFile("")
 {
 }
 

--- a/larpandoradlcontent/LArVertex/DlVertexingAlgorithm.cc
+++ b/larpandoradlcontent/LArVertex/DlVertexingAlgorithm.cc
@@ -891,7 +891,8 @@ StatusCode DlVertexingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 
 DlVertexingAlgorithm::VertexTuple::VertexTuple(
     const Pandora &pandora, const CartesianVector &vertexU, const CartesianVector &vertexV, const CartesianVector &vertexW) :
-    m_pos{0.f, 0.f, 0.f}, m_chi2{0.f}
+    m_pos{0.f, 0.f, 0.f},
+    m_chi2{0.f}
 {
     LArGeometryHelper::MergeThreePositions3D(pandora, TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W, vertexU, vertexV, vertexW, m_pos, m_chi2);
     if (m_chi2 > 1.f)
@@ -932,7 +933,8 @@ DlVertexingAlgorithm::VertexTuple::VertexTuple(
 
 DlVertexingAlgorithm::VertexTuple::VertexTuple(
     const Pandora &pandora, const CartesianVector &vertex1, const CartesianVector &vertex2, const HitType view1, const HitType view2) :
-    m_pos{0.f, 0.f, 0.f}, m_chi2{0.f}
+    m_pos{0.f, 0.f, 0.f},
+    m_chi2{0.f}
 {
     LArGeometryHelper::MergeTwoPositions3D(pandora, view1, view2, vertex1, vertex2, m_pos, m_chi2);
     std::cout << "Merging 2, position (" << m_pos.GetX() << ", " << m_pos.GetY() << ", " << m_pos.GetZ() << ") with chi2 " << m_chi2 << std::endl;


### PR DESCRIPTION
This PR includes updates to the clang-format file to accommodate changes induced by the recent upgrade to Clang 15. The new format has been applied across the entire repository. The changes in this PR are formatting only, there are no functional changes.