### PR TITLE
Cherry pick stitching thresholds to larpandoracontent v4_18 line

### DIFF
--- a/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
+++ b/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
@@ -844,6 +844,9 @@ StatusCode StitchingCosmicRayMergingTool::ReadSettings(const TiXmlHandle xmlHand
         XmlHelper::ReadValue(xmlHandle, "RelaxMinLongitudinalDisplacement", m_relaxMinLongitudinalDisplacement));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinLongitudinalDisplacementX", m_minLongitudinalDisplacementX));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
         XmlHelper::ReadValue(xmlHandle, "MaxLongitudinalDisplacementX", m_maxLongitudinalDisplacementX));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,

--- a/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
+++ b/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
@@ -29,6 +29,7 @@ StitchingCosmicRayMergingTool::StitchingCosmicRayMergingTool() :
     m_minLengthSquared(50.f),
     m_minCosRelativeAngle(0.966),
     m_relaxMinLongitudinalDisplacement(-5.f),
+    m_minLongitudinalDisplacementX(-1.f),
     m_maxLongitudinalDisplacementX(15.f),
     m_maxTransverseDisplacement(5.f),
     m_relaxCosRelativeAngle(0.906),
@@ -258,7 +259,7 @@ void StitchingCosmicRayMergingTool::CreatePfoMatches(const LArTPC &larTPC1, cons
 
     const float minL((!LArGeometryHelper::IsInGap(this->GetPandora(), pointingVertex1.GetPosition(), TPC_3D) ||
                          !LArGeometryHelper::IsInGap(this->GetPandora(), pointingVertex2.GetPosition(), TPC_3D))
-            ? -1.f
+            ? m_minLongitudinalDisplacementX
             : m_relaxMinLongitudinalDisplacement);
     const float dXdL1(m_useXcoordinate                                  ? pX1
             : (1.f - pX1 * pX1 > std::numeric_limits<float>::epsilon()) ? pX1 / std::sqrt(1.f - pX1 * pX1)

--- a/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.h
+++ b/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.h
@@ -235,6 +235,7 @@ private:
     float m_minLengthSquared;
     float m_minCosRelativeAngle;
     float m_relaxMinLongitudinalDisplacement; ///< The minimum value of the longitudinal impact parameter for association if both verticies fall in the detector gap
+    float m_minLongitudinalDisplacementX;
     float m_maxLongitudinalDisplacementX;
     float m_maxTransverseDisplacement;
     float m_relaxCosRelativeAngle;


### PR DESCRIPTION
In #94 , updates facilitating SBND + ICARUS productions were made. SBND also needs these in its Gen2 analyses using LArSoft v10_14_02_br. This PR cherry picks #94 and applies it to `v10_14_02_br`.