### PR TITLE
Cherry pick stitching in worker instances commits for SBND gen2 special release

### DIFF
--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -164,7 +164,7 @@
 #include "larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewTransverseTracksAlgorithm.h"
 
 #include "larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.h"
-#include "larpandoracontent/LArThreeDReco/LArPfoStitching/TrackPfoStitchingAlgorithm.h"
+#include "larpandoracontent/LArThreeDReco/LArPfoStitching/PfoStitchingAlgorithm.h"
 
 #include "larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.h"
 #include "larpandoracontent/LArVertex/EnergyKickFeatureTool.h"
@@ -348,7 +348,7 @@
     d("LArListDeletion",                        ListDeletionAlgorithm)                                                          \
     d("LArListMerging",                         ListMergingAlgorithm)                                                           \
     d("LArPfoHitCleaning",                      PfoHitCleaningAlgorithm)                                                        \
-    d("LArTrackPfoStitching",                   TrackPfoStitchingAlgorithm)                                                     \
+    d("LArPfoStitching",                        PfoStitchingAlgorithm)                                                          \
     d("LArListPruning",                         ListPruningAlgorithm)                                                           \
     d("LArThreeDReclustering",                  ThreeDReclusteringAlgorithm)                                                    \
     d("LArThreeDMultiReclustering",             ThreeDMultiReclusteringAlgorithm)                                               \

--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -41,7 +41,6 @@
 #include "larpandoracontent/LArControlFlow/PreProcessingAlgorithm.h"
 #include "larpandoracontent/LArControlFlow/SimpleNeutrinoIdTool.h"
 #include "larpandoracontent/LArControlFlow/SlicingAlgorithm.h"
-#include "larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.h"
 #include "larpandoracontent/LArControlFlow/StreamingAlgorithm.h"
 #include "larpandoracontent/LArControlFlow/TestBeamCosmicRayTaggingTool.h"
 
@@ -163,6 +162,8 @@
 #include "larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewSimpleTracksTool.h"
 #include "larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewThreeDKinkTool.h"
 #include "larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewTransverseTracksAlgorithm.h"
+
+#include "larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.h"
 
 #include "larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.h"
 #include "larpandoracontent/LArVertex/EnergyKickFeatureTool.h"

--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -164,6 +164,7 @@
 #include "larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewTransverseTracksAlgorithm.h"
 
 #include "larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.h"
+#include "larpandoracontent/LArThreeDReco/LArPfoStitching/TrackPfoStitchingAlgorithm.h"
 
 #include "larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.h"
 #include "larpandoracontent/LArVertex/EnergyKickFeatureTool.h"
@@ -347,6 +348,7 @@
     d("LArListDeletion",                        ListDeletionAlgorithm)                                                          \
     d("LArListMerging",                         ListMergingAlgorithm)                                                           \
     d("LArPfoHitCleaning",                      PfoHitCleaningAlgorithm)                                                        \
+    d("LArTrackPfoStitching",                   TrackPfoStitchingAlgorithm)                                                     \
     d("LArListPruning",                         ListPruningAlgorithm)                                                           \
     d("LArThreeDReclustering",                  ThreeDReclusteringAlgorithm)                                                    \
     d("LArThreeDMultiReclustering",             ThreeDMultiReclusteringAlgorithm)                                               \

--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.h
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.h
@@ -46,14 +46,6 @@ public:
      */
     MasterAlgorithm();
 
-    typedef std::unordered_map<const pandora::ParticleFlowObject *, const pandora::LArTPC *> PfoToLArTPCMap;
-
-    void ShiftPfoHierarchy(const pandora::ParticleFlowObject *const pParentPfo, const PfoToLArTPCMap &pfoToLArTPCMap,
-        const float x0) const override;
-
-    void StitchPfos(const pandora::ParticleFlowObject *const pPfoToEnlarge, const pandora::ParticleFlowObject *const pPfoToDelete,
-        PfoToLArTPCMap &pfoToLArTPCMap) const override;
-
     /**
      *  @brief  External steering parameters class
      */
@@ -69,6 +61,28 @@ public:
         pandora::InputBool m_shouldPerformSliceId;        ///< Whether to identify slices and select most appropriate pfos
         pandora::InputBool m_printOverallRecoStatus;      ///< Whether to print current operation status messages
     };
+
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, const pandora::LArTPC *> PfoToLArTPCMap;
+
+    /**
+     *  @brief  Shift a Pfo hierarchy by a specified x0 value
+     *
+     *  @param  pPfo the address of the parent pfo
+     *  @param  stitchingInfo  the source for additional, local, stitching information
+     *  @param  x0 the x0 correction relative to the input pfo
+     */
+    void ShiftPfoHierarchy(const pandora::ParticleFlowObject *const pParentPfo, const PfoToLArTPCMap &pfoToLArTPCMap,
+        const float x0) const override;
+
+    /**
+     *  @brief  Stitch together a pair of pfos
+     *
+     *  @param  pPfoToEnlarge the address of the pfo to enlarge
+     *  @param  pPfoToDelete the address of the pfo to delete (will become a dangling pointer)
+     *  @param  pfoToLArTPCMap the pfo to lar tpc map
+     */
+    void StitchPfos(const pandora::ParticleFlowObject *const pPfoToEnlarge, const pandora::ParticleFlowObject *const pPfoToDelete,
+        PfoToLArTPCMap &pfoToLArTPCMap) const override;
 
 protected:
     /**

--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.h
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.h
@@ -67,8 +67,8 @@ public:
     /**
      *  @brief  Shift a Pfo hierarchy by a specified x0 value
      *
-     *  @param  pPfo the address of the parent pfo
-     *  @param  stitchingInfo  the source for additional, local, stitching information
+     *  @param  pParentPfo the address of the parent pfo
+     *  @param  pfoToLArTPCMap the pfo to lar tpc map
      *  @param  x0 the x0 correction relative to the input pfo
      */
     void ShiftPfoHierarchy(const pandora::ParticleFlowObject *const pParentPfo, const PfoToLArTPCMap &pfoToLArTPCMap,

--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.h
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.h
@@ -30,8 +30,6 @@ class LArMCParticleFactory;
 
 typedef std::vector<pandora::CaloHitList> SliceVector;
 typedef std::vector<pandora::PfoList> SliceHypotheses;
-typedef std::unordered_map<const pandora::ParticleFlowObject *, const pandora::LArTPC *> PfoToLArTPCMap;
-typedef std::unordered_map<const pandora::ParticleFlowObject *, float> PfoToFloatMap;
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -61,8 +59,6 @@ public:
         pandora::InputBool m_shouldPerformSliceId;        ///< Whether to identify slices and select most appropriate pfos
         pandora::InputBool m_printOverallRecoStatus;      ///< Whether to print current operation status messages
     };
-
-    typedef std::unordered_map<const pandora::ParticleFlowObject *, const pandora::LArTPC *> PfoToLArTPCMap;
 
     /**
      *  @brief  Shift a Pfo hierarchy by a specified x0 value

--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.h
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.h
@@ -19,6 +19,7 @@
 #include "larpandoracontent/LArControlFlow/SliceSelectionBaseTool.h"
 
 #include "larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingBaseTool.h"
+#include "larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingPfoOperations.h"
 
 #include <unordered_map>
 
@@ -37,13 +38,21 @@ typedef std::unordered_map<const pandora::ParticleFlowObject *, float> PfoToFloa
 /**
  *  @brief  MasterAlgorithm class
  */
-class MasterAlgorithm : public pandora::ExternallyConfiguredAlgorithm
+class MasterAlgorithm : public pandora::ExternallyConfiguredAlgorithm, public StitchingPfoOperations
 {
 public:
     /**
      *  @brief  Default constructor
      */
     MasterAlgorithm();
+
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, const pandora::LArTPC *> PfoToLArTPCMap;
+
+    void ShiftPfoHierarchy(const pandora::ParticleFlowObject *const pParentPfo, const PfoToLArTPCMap &pfoToLArTPCMap,
+        const float x0) const override;
+
+    void StitchPfos(const pandora::ParticleFlowObject *const pPfoToEnlarge, const pandora::ParticleFlowObject *const pPfoToDelete,
+        PfoToLArTPCMap &pfoToLArTPCMap) const override;
 
     /**
      *  @brief  External steering parameters class
@@ -60,27 +69,6 @@ public:
         pandora::InputBool m_shouldPerformSliceId;        ///< Whether to identify slices and select most appropriate pfos
         pandora::InputBool m_printOverallRecoStatus;      ///< Whether to print current operation status messages
     };
-
-    typedef std::unordered_map<const pandora::ParticleFlowObject *, const pandora::LArTPC *> PfoToLArTPCMap;
-
-    /**
-     *  @brief  Shift a Pfo hierarchy by a specified x0 value
-     *
-     *  @param  pPfo the address of the parent pfo
-     *  @param  stitchingInfo  the source for additional, local, stitching information
-     *  @param  x0 the x0 correction relative to the input pfo
-     */
-    void ShiftPfoHierarchy(const pandora::ParticleFlowObject *const pParentPfo, const PfoToLArTPCMap &pfoToLArTPCMap, const float x0) const;
-
-    /**
-     *  @brief  Stitch together a pair of pfos
-     *
-     *  @param  pPfoToEnlarge the address of the pfo to enlarge
-     *  @param  pPfoToDelete the address of the pfo to delete (will become a dangling pointer)
-     *  @param  stitchingInfo the source for additional, local, stitching information
-     */
-    void StitchPfos(const pandora::ParticleFlowObject *const pPfoToEnlarge, const pandora::ParticleFlowObject *const pPfoToDelete,
-        PfoToLArTPCMap &pfoToLArTPCMap) const;
 
 protected:
     /**

--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.h
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.h
@@ -17,7 +17,8 @@
 #include "larpandoracontent/LArControlFlow/CosmicRayTaggingBaseTool.h"
 #include "larpandoracontent/LArControlFlow/SliceIdBaseTool.h"
 #include "larpandoracontent/LArControlFlow/SliceSelectionBaseTool.h"
-#include "larpandoracontent/LArControlFlow/StitchingBaseTool.h"
+
+#include "larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingBaseTool.h"
 
 #include <unordered_map>
 

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/PfoStitchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/PfoStitchingAlgorithm.cc
@@ -41,8 +41,15 @@ StatusCode PfoStitchingAlgorithm::Run()
 {
     PANDORA_RETURN_IF(STATUS_CODE_SUCCESS, m_stitchingToolVector.empty());
 
-    const PfoList *pPfoList{nullptr};
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_inputPfoListName, pPfoList));
+    PfoList sortedPfos;
+    for (const std::string &listName : m_inputPfoListNames)
+    {
+        const PfoList *pPfos{nullptr};
+        if (PandoraContentApi::GetList(*this, listName, pPfos) == STATUS_CODE_SUCCESS)
+            sortedPfos.insert(sortedPfos.end(), pPfos->begin(), pPfos->end());
+    }
+    sortedPfos.sort(LArPfoHelper::SortByNHits);
+    const PfoList *const pSortedPfoList{&sortedPfos};
 
     InferredLArTPCVector inferredTPCs;
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->InferLArTPCs(inferredTPCs));
@@ -50,13 +57,13 @@ StatusCode PfoStitchingAlgorithm::Run()
         return STATUS_CODE_SUCCESS;
 
     PfoToLArTPCMap pfoToLArTPCMap;
-    this->GetPfoToLArTPCMap(pPfoList, inferredTPCs, pfoToLArTPCMap);
+    this->GetPfoToLArTPCMap(pSortedPfoList, inferredTPCs, pfoToLArTPCMap);
     if (pfoToLArTPCMap.empty())
         return STATUS_CODE_SUCCESS;
 
     PfoToFloatMap stitchedPfosToX0Map;
     for (StitchingBaseTool *const pStitchingTool : m_stitchingToolVector)
-        pStitchingTool->Run(this, pPfoList, pfoToLArTPCMap, stitchedPfosToX0Map);
+        pStitchingTool->Run(this, pSortedPfoList, pfoToLArTPCMap, stitchedPfosToX0Map);
 
     return STATUS_CODE_SUCCESS;
 }
@@ -183,7 +190,6 @@ const std::string PfoStitchingAlgorithm::GetListName(const Cluster *const pClust
             return listName;
         }
     }
-
     PANDORA_THROW(STATUS_CODE_NOT_FOUND);
 }
 
@@ -200,7 +206,22 @@ const std::string PfoStitchingAlgorithm::GetListName(const Vertex *const pVertex
             return listName;
         }
     }
+    PANDORA_THROW(STATUS_CODE_NOT_FOUND);
+}
 
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const std::string PfoStitchingAlgorithm::GetInputListName(const ParticleFlowObject *const pPfo) const
+{
+    for (const std::string &listName : m_inputPfoListNames)
+    {
+        const PfoList *pPfoList{nullptr};
+        if ((PandoraContentApi::GetList(*this, listName, pPfoList) == STATUS_CODE_SUCCESS) &&
+            (pPfoList->end() != std::find(pPfoList->begin(), pPfoList->end(), pPfo)))
+        {
+            return listName;
+        }
+    }
     PANDORA_THROW(STATUS_CODE_NOT_FOUND);
 }
 
@@ -237,7 +258,7 @@ void PfoStitchingAlgorithm::StitchPfos(
     const ClusterVector daughterClusters(pPfoToDelete->GetClusterList().begin(), pPfoToDelete->GetClusterList().end());
     const VertexVector daughterVertices(pPfoToDelete->GetVertexList().begin(), pPfoToDelete->GetVertexList().end());
 
-    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Delete(*this, pPfoToDelete, m_inputPfoListName));
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Delete(*this, pPfoToDelete, this->GetInputListName(pPfoToDelete)));
 
     for (const ParticleFlowObject *const pDaughterPfo : daughterPfos)
     {
@@ -273,7 +294,7 @@ void PfoStitchingAlgorithm::StitchPfos(
 
 StatusCode PfoStitchingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "InputPfoListName", m_inputPfoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "InputPfoListNames", m_inputPfoListNames));
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
         XmlHelper::ReadVectorOfValues(xmlHandle, "DaughterListNames", m_daughterListNames));
 

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/PfoStitchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/PfoStitchingAlgorithm.cc
@@ -1,5 +1,5 @@
 /**
- *  @file   larpandoracontent/LArThreeDReco/LArPfoStitching/TrackPfoStitchingAlgorithm.cc
+ *  @file   larpandoracontent/LArThreeDReco/LArPfoStitching/PfoStitchingAlgorithm.cc
  *
  *  @brief  Implementation of the track pfo stitching algorithm class.
  *
@@ -11,7 +11,7 @@
 #include "Geometry/DetectorGap.h"
 #include "Geometry/LArTPC.h"
 
-#include "larpandoracontent/LArThreeDReco/LArPfoStitching/TrackPfoStitchingAlgorithm.h"
+#include "larpandoracontent/LArThreeDReco/LArPfoStitching/PfoStitchingAlgorithm.h"
 
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
 #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
@@ -23,21 +23,21 @@ using namespace pandora;
 namespace lar_content
 {
 
-TrackPfoStitchingAlgorithm::InferredLArTPC::InferredLArTPC(const PandoraApi::Geometry::LArTPC::Parameters &parameters) :
+PfoStitchingAlgorithm::InferredLArTPC::InferredLArTPC(const PandoraApi::Geometry::LArTPC::Parameters &parameters) :
     LArTPC(parameters)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-TrackPfoStitchingAlgorithm::TrackPfoStitchingAlgorithm() :
+PfoStitchingAlgorithm::PfoStitchingAlgorithm() :
     m_visualise{false}
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode TrackPfoStitchingAlgorithm::Run()
+StatusCode PfoStitchingAlgorithm::Run()
 {
     PANDORA_RETURN_IF(STATUS_CODE_SUCCESS, m_stitchingToolVector.empty());
 
@@ -63,7 +63,7 @@ StatusCode TrackPfoStitchingAlgorithm::Run()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode TrackPfoStitchingAlgorithm::InferLArTPCs(InferredLArTPCVector &inferredTPCs) const
+StatusCode PfoStitchingAlgorithm::InferLArTPCs(InferredLArTPCVector &inferredTPCs) const
 {
     const LArTPC &parentLArTPC(this->GetPandora().GetGeometry()->GetLArTPC());
     const float parentMinX(parentLArTPC.GetCenterX() - 0.5f * parentLArTPC.GetWidthX());
@@ -127,12 +127,12 @@ StatusCode TrackPfoStitchingAlgorithm::InferLArTPCs(InferredLArTPCVector &inferr
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrackPfoStitchingAlgorithm::GetPfoToLArTPCMap(const PfoList *const pPfoList, const InferredLArTPCVector &inferredTPCs,
+void PfoStitchingAlgorithm::GetPfoToLArTPCMap(const PfoList *const pPfoList, const InferredLArTPCVector &inferredTPCs,
     PfoToLArTPCMap &pfoToLArTPCMap) const
 {
     for (const ParticleFlowObject *const pPfo : *pPfoList)
     {
-        if (!LArPfoHelper::IsTrack(pPfo) || LArPfoHelper::IsNeutrino(pPfo))
+        if (LArPfoHelper::IsNeutrino(pPfo))
             continue;
 
         CartesianPointVector positions;
@@ -172,7 +172,7 @@ void TrackPfoStitchingAlgorithm::GetPfoToLArTPCMap(const PfoList *const pPfoList
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-const std::string TrackPfoStitchingAlgorithm::GetListName(const Cluster *const pCluster) const
+const std::string PfoStitchingAlgorithm::GetListName(const Cluster *const pCluster) const
 {
     for (const std::string &listName : m_daughterListNames)
     {
@@ -189,7 +189,7 @@ const std::string TrackPfoStitchingAlgorithm::GetListName(const Cluster *const p
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-const std::string TrackPfoStitchingAlgorithm::GetListName(const Vertex *const pVertex) const
+const std::string PfoStitchingAlgorithm::GetListName(const Vertex *const pVertex) const
 {
     for (const std::string &listName : m_daughterListNames)
     {
@@ -206,16 +206,16 @@ const std::string TrackPfoStitchingAlgorithm::GetListName(const Vertex *const pV
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrackPfoStitchingAlgorithm::ShiftPfoHierarchy([[maybe_unused]]const ParticleFlowObject *const pParentPfo,
+void PfoStitchingAlgorithm::ShiftPfoHierarchy([[maybe_unused]]const ParticleFlowObject *const pParentPfo,
     [[maybe_unused]]const PfoToLArTPCMap &pfoToLArTPCMap, [[maybe_unused]]const float x0) const
 {
-    std::cout << "TrackPfoStitchingAlgorithm: Stitching tools must not be configured to apply an x0 correction" << std::endl;
+    std::cout << "PfoStitchingAlgorithm: Stitching tools must not be configured to apply an x0 correction" << std::endl;
     PANDORA_THROW(STATUS_CODE_NOT_ALLOWED);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrackPfoStitchingAlgorithm::StitchPfos(
+void PfoStitchingAlgorithm::StitchPfos(
     const ParticleFlowObject *const pPfoToEnlarge, const ParticleFlowObject *const pPfoToDelete, PfoToLArTPCMap &pfoToLArTPCMap) const
 {
     PANDORA_THROW_IF(STATUS_CODE_NOT_ALLOWED, pPfoToEnlarge == pPfoToDelete);
@@ -271,7 +271,7 @@ void TrackPfoStitchingAlgorithm::StitchPfos(
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode TrackPfoStitchingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
+StatusCode PfoStitchingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "InputPfoListName", m_inputPfoListName));
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/PfoStitchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/PfoStitchingAlgorithm.cc
@@ -84,7 +84,7 @@ StatusCode PfoStitchingAlgorithm::InferLArTPCs(InferredLArTPCVector &inferredTPC
         if (!pLineGap || (pLineGap->GetLineGapType() != TPC_DRIFT_GAP))
             continue;
 
-        PANDORA_RETURN_IF(STATUS_CODE_INVALID_PARAMETER, pLineGap->GetLineStartX() > pLineGap->GetLineEndX())
+        PANDORA_RETURN_IF(STATUS_CODE_INVALID_PARAMETER, pLineGap->GetLineStartX() > pLineGap->GetLineEndX());
 
         if (pLineGap->GetLineStartX() < parentMinX || pLineGap->GetLineEndX() > parentMaxX)
             continue;
@@ -147,6 +147,8 @@ void PfoStitchingAlgorithm::GetPfoToLArTPCMap(const PfoList *const pPfoList, con
         CartesianPointVector positions;
         LArPfoHelper::GetCoordinateVector(pPfo, TPC_3D, positions);
 
+        // Find the LArTPC for PFOs contained in a single LArTPC
+        // ATTN We should try relaxing this to stitch particles that span > 2 LArTPCs, would require dev in stitching tool & its helpers
         const LArTPC *pLArTPC{nullptr};
         for (const CartesianVector &pos : positions)
         {
@@ -165,7 +167,7 @@ void PfoStitchingAlgorithm::GetPfoToLArTPCMap(const PfoList *const pPfoList, con
             if (!pPosLArTPC) // 3D hit ended up in a gap or outside detector, ignoring it
                 continue;
 
-            if (pLArTPC && pLArTPC != pPosLArTPC)
+            if (pLArTPC && pLArTPC != pPosLArTPC) // Hits in > 1 LArTPC so PFO is not a stitching candidate, giving up
             {
                 pLArTPC = nullptr;
                 break;
@@ -183,43 +185,33 @@ void PfoStitchingAlgorithm::GetPfoToLArTPCMap(const PfoList *const pPfoList, con
 
 const std::string PfoStitchingAlgorithm::GetListName(const Cluster *const pCluster) const
 {
-    for (const std::string &listName : m_daughterListNames)
-    {
-        const ClusterList *pClusterList{nullptr};
-        if ((PandoraContentApi::GetList(*this, listName, pClusterList) == STATUS_CODE_SUCCESS) &&
-            (pClusterList->end() != std::find(pClusterList->begin(), pClusterList->end(), pCluster)))
-        {
-            return listName;
-        }
-    }
-    PANDORA_THROW(STATUS_CODE_NOT_FOUND);
+    return this->GetListName<Cluster, ClusterList>(pCluster, m_daughterListNames);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 const std::string PfoStitchingAlgorithm::GetListName(const Vertex *const pVertex) const
 {
-    for (const std::string &listName : m_daughterListNames)
-    {
-        const VertexList *pVertexList{nullptr};
-        if ((PandoraContentApi::GetList(*this, listName, pVertexList) == STATUS_CODE_SUCCESS) &&
-            (pVertexList->end() != std::find(pVertexList->begin(), pVertexList->end(), pVertex)))
-        {
-            return listName;
-        }
-    }
-    PANDORA_THROW(STATUS_CODE_NOT_FOUND);
+    return this->GetListName<Vertex, VertexList>(pVertex, m_daughterListNames);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-const std::string PfoStitchingAlgorithm::GetInputListName(const ParticleFlowObject *const pPfo) const
+const std::string PfoStitchingAlgorithm::GetListName(const ParticleFlowObject *const pPfo) const
 {
-    for (const std::string &listName : m_inputPfoListNames)
+    return this->GetListName<ParticleFlowObject, PfoList>(pPfo, m_inputPfoListNames);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+template <typename TObject, typename TList>
+const std::string PfoStitchingAlgorithm::GetListName(const TObject *const pObject, const StringVector &listNames) const
+{
+    for (const std::string &listName : listNames)
     {
-        const PfoList *pPfoList{nullptr};
-        if ((PandoraContentApi::GetList(*this, listName, pPfoList) == STATUS_CODE_SUCCESS) &&
-            (pPfoList->end() != std::find(pPfoList->begin(), pPfoList->end(), pPfo)))
+        const TList *pObjectList{nullptr};
+        if ((PandoraContentApi::GetList(*this, listName, pObjectList) == STATUS_CODE_SUCCESS) &&
+            (pObjectList->end() != std::find(pObjectList->begin(), pObjectList->end(), pObject)))
         {
             return listName;
         }
@@ -260,7 +252,7 @@ void PfoStitchingAlgorithm::StitchPfos(
     const ClusterVector daughterClusters(pPfoToDelete->GetClusterList().begin(), pPfoToDelete->GetClusterList().end());
     const VertexVector daughterVertices(pPfoToDelete->GetVertexList().begin(), pPfoToDelete->GetVertexList().end());
 
-    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Delete(*this, pPfoToDelete, this->GetInputListName(pPfoToDelete)));
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Delete(*this, pPfoToDelete, this->GetListName(pPfoToDelete)));
 
     for (const ParticleFlowObject *const pDaughterPfo : daughterPfos)
     {
@@ -297,8 +289,7 @@ void PfoStitchingAlgorithm::StitchPfos(
 StatusCode PfoStitchingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "InputPfoListNames", m_inputPfoListNames));
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
-        XmlHelper::ReadVectorOfValues(xmlHandle, "DaughterListNames", m_daughterListNames));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "DaughterListNames", m_daughterListNames));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
         XmlHelper::ReadValue(xmlHandle, "Visualise", m_visualise));

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/PfoStitchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/PfoStitchingAlgorithm.cc
@@ -84,9 +84,11 @@ StatusCode PfoStitchingAlgorithm::InferLArTPCs(InferredLArTPCVector &inferredTPC
         if (!pLineGap || (pLineGap->GetLineGapType() != TPC_DRIFT_GAP))
             continue;
 
-        PANDORA_RETURN_IF(STATUS_CODE_INVALID_PARAMETER,
-            pLineGap->GetLineStartX() > pLineGap->GetLineEndX() ||
-            pLineGap->GetLineStartX() < parentMinX || pLineGap->GetLineEndX() > parentMaxX);
+        PANDORA_RETURN_IF(STATUS_CODE_INVALID_PARAMETER, pLineGap->GetLineStartX() > pLineGap->GetLineEndX())
+
+        if (pLineGap->GetLineStartX() < parentMinX || pLineGap->GetLineEndX() > parentMaxX)
+            continue;
+
         driftGapXIntervals.emplace_back(pLineGap->GetLineStartX(), pLineGap->GetLineEndX());
     }
 

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/PfoStitchingAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/PfoStitchingAlgorithm.h
@@ -87,7 +87,7 @@ private:
         const pandora::PfoList *const pPfoList, const InferredLArTPCVector &inferredLArTPCs, PfoToLArTPCMap &pfoToLArTPCMap) const;
 
     /**
-     *  @brief  Find the named list containing a cluster or vertex used by a pfo in the input list
+     *  @brief  Find the named list containing a cluster used by a pfo in the input list
      *
      *  @param[in]  pCluster the cluster whose list is required
      *
@@ -96,7 +96,7 @@ private:
     const std::string GetListName(const pandora::Cluster *const pCluster) const;
 
     /**
-     *  @brief  Find the named list containing a cluster or vertex used by a pfo in the input list
+     *  @brief  Find the named list containing a vertex used by a pfo in the input list
      *
      *  @param[in]  pVertex the vertex whose list is required
      *
@@ -104,9 +104,18 @@ private:
      */
     const std::string GetListName(const pandora::Vertex *const pVertex) const;
 
+    /**
+     *  @brief  Find the named list containing the input pfo
+     *
+     *  @param[in]  pPfo the input pfo whose list is required
+     *
+     *  @return the list name
+     */
+    const std::string GetInputListName(const pandora::ParticleFlowObject *const pPfo) const;
+
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle) override;
 
-    std::string m_inputPfoListName;            ///< The list containing pfos to stitch
+    pandora::StringVector m_inputPfoListNames; ///< The input pfo list names
     pandora::StringVector m_daughterListNames; ///< Cluster and vertex lists used by the input pfos, updated when pfos are merged
     StitchingToolVector m_stitchingToolVector; ///< The stitching tools to be applied
     bool m_visualise;                          ///< Visualise merges

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/PfoStitchingAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/PfoStitchingAlgorithm.h
@@ -111,7 +111,18 @@ private:
      *
      *  @return the list name
      */
-    const std::string GetInputListName(const pandora::ParticleFlowObject *const pPfo) const;
+    const std::string GetListName(const pandora::ParticleFlowObject *const pPfo) const;
+
+    /**
+     *  @brief  Find the named list containing the input object
+     *
+     *  @param[in]  pObject the object whose list is required
+     *  @param[in]  listNames the list names to search
+     *
+     *  @return the list name
+     */
+    template <typename TObject, typename TList>
+    const std::string GetListName(const TObject *const pObject, const pandora::StringVector &listNames) const;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle) override;
 

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/PfoStitchingAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/PfoStitchingAlgorithm.h
@@ -1,12 +1,12 @@
 /**
- *  @file   larpandoracontent/LArThreeDReco/LArPfoStitching/TrackPfoStitchingAlgorithm.h
+ *  @file   larpandoracontent/LArThreeDReco/LArPfoStitching/PfoStitchingAlgorithm.h
  *
  *  @brief  Header file for the track pfo stitching algorithm class.
  *
  *  $Log: $
  */
-#ifndef LAR_TRACK_PFO_STITCHING_ALGORITHM_H
-#define LAR_TRACK_PFO_STITCHING_ALGORITHM_H 1
+#ifndef LAR_PFO_STITCHING_ALGORITHM_H
+#define LAR_PFO_STITCHING_ALGORITHM_H 1
 
 #include "Pandora/Algorithm.h"
 #include "Api/PandoraApi.h"
@@ -23,9 +23,9 @@ namespace lar_content
 {
 
 /**
- *  @brief  TrackPfoStitchingAlgorithm class
+ *  @brief  PfoStitchingAlgorithm class
  */
-class TrackPfoStitchingAlgorithm : public pandora::Algorithm, public StitchingPfoOperations
+class PfoStitchingAlgorithm : public pandora::Algorithm, public StitchingPfoOperations
 {
 public:
     /**
@@ -41,7 +41,7 @@ public:
     /**
      *  @brief  Default constructor
      */
-    TrackPfoStitchingAlgorithm();
+    PfoStitchingAlgorithm();
 
     /**
      *  @brief  Shift a Pfo hierarchy by a specified x0 value
@@ -114,4 +114,4 @@ private:
 
 } // namespace lar_content
 
-#endif // #ifndef LAR_TRACK_PFO_STITCHING_ALGORITHM_H
+#endif // #ifndef LAR_PFO_STITCHING_ALGORITHM_H

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingBaseTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingBaseTool.cc
@@ -1,0 +1,30 @@
+/**
+ *  @file   larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingBaseTool.cc
+ *
+ *  @brief  Implementation file for the stitching tool base class
+ *
+ *  $Log: $
+ */
+
+#include "larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingBaseTool.h"
+#include "larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingPfoOperations.h"
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+void StitchingBaseTool::Run(const Algorithm *const pAlgorithm, const PfoList *const pMultiPfoList, PfoToLArTPCMap &pfoToLArTPCMap,
+    PfoToFloatMap &stitchedPfosToX0Map)
+{
+    const StitchingPfoOperations *const pStitchingOperations{dynamic_cast<const StitchingPfoOperations *>(pAlgorithm)};
+    if (!pStitchingOperations)
+    {
+        std::cout << "StitchingBaseTool: Calling algorithm must implement StitchingPfoOperations" << std::endl;
+        PANDORA_THROW(STATUS_CODE_INVALID_PARAMETER);
+    }
+
+    this->RunStitching(pAlgorithm, pStitchingOperations, pMultiPfoList, pfoToLArTPCMap, stitchedPfosToX0Map);
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingBaseTool.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingBaseTool.h
@@ -1,5 +1,5 @@
 /**
- *  @file   larpandoracontent/LArControlFlow/StitchingBaseTool.h
+ *  @file   larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingBaseTool.h
  *
  *  @brief  Header file for the stitching tool base class.
  *

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingBaseTool.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingBaseTool.h
@@ -9,13 +9,12 @@
 #define LAR_STITCHING_BASE_TOOL_H 1
 
 #include "Pandora/AlgorithmTool.h"
+#include "Pandora/Algorithm.h"
 
-#include "larpandoracontent/LArControlFlow/MasterAlgorithm.h"
+#include "larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingPfoOperations.h"
 
 namespace lar_content
 {
-
-class MasterAlgorithm;
 
 typedef std::unordered_map<const pandora::ParticleFlowObject *, const pandora::LArTPC *> PfoToLArTPCMap;
 typedef std::unordered_map<const pandora::ParticleFlowObject *, float> PfoToFloatMap;
@@ -33,8 +32,22 @@ public:
      *  @param  pfoToLArTPCMap the pfo to lar tpc map
      *  @param  stitchedPfosToX0Map a map of cosmic-ray pfos that have been stitched between lar tpcs to the X0 shift
      */
-    virtual void Run(const MasterAlgorithm *const pAlgorithm, const pandora::PfoList *const pMultiPfoList, PfoToLArTPCMap &pfoToLArTPCMap,
-        PfoToFloatMap &stitchedPfosToX0Map) = 0;
+    void Run(const pandora::Algorithm *const pAlgorithm, const pandora::PfoList *const pMultiPfoList, PfoToLArTPCMap &pfoToLArTPCMap,
+        PfoToFloatMap &stitchedPfosToX0Map);
+
+protected:
+    /**
+     *  @brief  Run the stitching logic
+     *
+     *  @param  pAlgorithm address of the calling algorithm
+     *  @param  pAlgorithm address of the calling algorithm's stitching operations implementation
+     *  @param  pMultiPfoList the list of pfos in multiple lar tpcs
+     *  @param  pfoToLArTPCMap the pfo to lar tpc map
+     *  @param  stitchedPfosToX0Map a map of cosmic-ray pfos that have been stitched between lar tpcs to the X0 shift
+     */
+    virtual void RunStitching(const pandora::Algorithm *const pAlgorithm, const StitchingPfoOperations *const pStitchingOperations,
+        const pandora::PfoList *const pMultiPfoList, PfoToLArTPCMap &pfoToLArTPCMap, PfoToFloatMap &stitchedPfosToX0Map) = 0;
+
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingBaseTool.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingBaseTool.h
@@ -40,7 +40,7 @@ protected:
      *  @brief  Run the stitching logic
      *
      *  @param  pAlgorithm address of the calling algorithm
-     *  @param  pAlgorithm address of the calling algorithm's stitching operations implementation
+     *  @param  pStitchingOperations address of the calling algorithm's stitching operations implementation
      *  @param  pMultiPfoList the list of pfos in multiple lar tpcs
      *  @param  pfoToLArTPCMap the pfo to lar tpc map
      *  @param  stitchedPfosToX0Map a map of cosmic-ray pfos that have been stitched between lar tpcs to the X0 shift

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingBaseTool.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingBaseTool.h
@@ -16,14 +16,15 @@
 namespace lar_content
 {
 
-typedef std::unordered_map<const pandora::ParticleFlowObject *, const pandora::LArTPC *> PfoToLArTPCMap;
-typedef std::unordered_map<const pandora::ParticleFlowObject *, float> PfoToFloatMap;
 /**
  *  @brief  StitchingBaseTool class
  */
 class StitchingBaseTool : public pandora::AlgorithmTool
 {
 public:
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, const pandora::LArTPC *> PfoToLArTPCMap;
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, float> PfoToFloatMap;
+
     /**
      *  @brief  Run the algorithm tool
      *

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.cc
@@ -48,11 +48,13 @@ void StitchingCosmicRayMergingTool::RunStitching(const Algorithm *const pAlgorit
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
         std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
-    if (this->GetPandora().GetGeometry()->GetLArTPCMap().size() < 2)
-        return;
-
     if (pfoToLArTPCMap.empty())
         throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+
+    const unsigned int firstVolId{pfoToLArTPCMap.begin()->second->GetLArTPCVolumeId()};
+    if (std::all_of(std::next(pfoToLArTPCMap.begin()), pfoToLArTPCMap.end(),
+        [&](const auto &iter){ return iter.second->GetLArTPCVolumeId() == firstVolId; }))
+        return;
 
     PfoList primaryPfos;
     this->SelectPrimaryPfos(pMultiPfoList, pfoToLArTPCMap, primaryPfos);

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.cc
@@ -49,8 +49,11 @@ void StitchingCosmicRayMergingTool::RunStitching(const Algorithm *const pAlgorit
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
         std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
+    if (this->GetPandora().GetGeometry()->GetLArTPCMap().empty())
+        return;
+
     if (pfoToLArTPCMap.empty())
-        throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+        return;
 
     const unsigned int firstVolId{pfoToLArTPCMap.begin()->second->GetLArTPCVolumeId()};
     if (std::all_of(std::next(pfoToLArTPCMap.begin()), pfoToLArTPCMap.end(),

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.cc
@@ -37,7 +37,8 @@ StitchingCosmicRayMergingTool::StitchingCosmicRayMergingTool() :
     m_relaxTransverseDisplacement(2.5f),
     m_minNCaloHits3D(0),
     m_maxX0FractionalDeviation(0.3f),
-    m_boundaryToleranceWidth(10.f)
+    m_boundaryToleranceWidth(10.f),
+    m_onlyFinalStatePfos(true)
 {
 }
 
@@ -56,14 +57,14 @@ void StitchingCosmicRayMergingTool::RunStitching(const Algorithm *const pAlgorit
         [&](const auto &iter){ return iter.second->GetLArTPCVolumeId() == firstVolId; }))
         return;
 
-    PfoList primaryPfos;
-    this->SelectPrimaryPfos(pMultiPfoList, pfoToLArTPCMap, primaryPfos);
+    PfoList pfos;
+    this->SelectPfos(pMultiPfoList, pfoToLArTPCMap, pfos);
 
     ThreeDPointingClusterMap pointingClusterMap;
-    this->BuildPointingClusterMaps(primaryPfos, pfoToLArTPCMap, pointingClusterMap);
+    this->BuildPointingClusterMaps(pfos, pfoToLArTPCMap, pointingClusterMap);
 
     LArTPCToPfoMap larTPCToPfoMap;
-    this->BuildTPCMaps(primaryPfos, pfoToLArTPCMap, larTPCToPfoMap);
+    this->BuildTPCMaps(pfos, pfoToLArTPCMap, larTPCToPfoMap);
 
     PfoAssociationMatrix pfoAssociationMatrix;
     this->CreatePfoMatches(larTPCToPfoMap, pointingClusterMap, pfoAssociationMatrix);
@@ -82,11 +83,11 @@ void StitchingCosmicRayMergingTool::RunStitching(const Algorithm *const pAlgorit
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void StitchingCosmicRayMergingTool::SelectPrimaryPfos(const PfoList *pInputPfoList, const PfoToLArTPCMap &pfoToLArTPCMap, PfoList &outputPfoList) const
+void StitchingCosmicRayMergingTool::SelectPfos(const PfoList *pInputPfoList, const PfoToLArTPCMap &pfoToLArTPCMap, PfoList &outputPfoList) const
 {
     for (const ParticleFlowObject *const pPfo : *pInputPfoList)
     {
-        if (!LArPfoHelper::IsFinalState(pPfo) || !LArPfoHelper::IsTrack(pPfo))
+        if ((m_onlyFinalStatePfos && !LArPfoHelper::IsFinalState(pPfo)) || !LArPfoHelper::IsTrack(pPfo))
             continue;
 
         if (!pfoToLArTPCMap.count(pPfo))
@@ -533,6 +534,21 @@ void StitchingCosmicRayMergingTool::OrderPfoMerges(const PfoToLArTPCMap &pfoToLA
                         throw StatusCodeException(STATUS_CODE_NOT_FOUND);
 
                     pVertexPfo = ((deltaY > 0.f) ? pPfo1 : pPfo2);
+
+                    if (!m_onlyFinalStatePfos) // vertex PFO could be downstream in the hierarchy, need to swap if we find this
+                    {
+                        const ParticleFlowObject *pNonVertexPfo{(pPfo1 == pVertexPfo) ? pPfo2 : pPfo1};
+                        PfoList downstreamPfos;
+                        LArPfoHelper::GetAllDownstreamPfos(pNonVertexPfo, downstreamPfos);
+                        for (const ParticleFlowObject *pPfo : downstreamPfos)
+                        {
+                            if (pPfo == pVertexPfo)
+                            {
+                                pVertexPfo = pNonVertexPfo;
+                                break;
+                            }
+                        }
+                    }
                 }
                 catch (const pandora::StatusCodeException &)
                 {
@@ -870,6 +886,9 @@ StatusCode StitchingCosmicRayMergingTool::ReadSettings(const TiXmlHandle xmlHand
 
     PANDORA_RETURN_RESULT_IF_AND_IF(
         STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "BoundaryToleranceWidth", m_boundaryToleranceWidth));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "OnlyFinalStatePfos", m_onlyFinalStatePfos));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.cc
@@ -16,6 +16,7 @@
 #include "larpandoracontent/LArObjects/LArThreeDSlidingFitResult.h"
 
 #include "larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.h"
+#include "larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingPfoOperations.h"
 
 using namespace pandora;
 
@@ -40,8 +41,9 @@ StitchingCosmicRayMergingTool::StitchingCosmicRayMergingTool() :
 {
 }
 
-void StitchingCosmicRayMergingTool::Run(const MasterAlgorithm *const pAlgorithm, const PfoList *const pMultiPfoList,
-    PfoToLArTPCMap &pfoToLArTPCMap, PfoToFloatMap &stitchedPfosToX0Map)
+void StitchingCosmicRayMergingTool::RunStitching(const Algorithm *const pAlgorithm,
+    const StitchingPfoOperations *const pStitchingOperations, const PfoList *const pMultiPfoList, PfoToLArTPCMap &pfoToLArTPCMap,
+    PfoToFloatMap &stitchedPfosToX0Map)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
         std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
@@ -73,7 +75,7 @@ void StitchingCosmicRayMergingTool::Run(const MasterAlgorithm *const pAlgorithm,
     PfoMergeMap pfoOrderedMerges;
     this->OrderPfoMerges(pfoToLArTPCMap, pointingClusterMap, pfoSelectedMerges, pfoOrderedMerges);
 
-    this->StitchPfos(pAlgorithm, pointingClusterMap, pfoOrderedMerges, pfoToLArTPCMap, stitchedPfosToX0Map);
+    this->StitchPfos(pAlgorithm, pStitchingOperations, pointingClusterMap, pfoOrderedMerges, pfoToLArTPCMap, stitchedPfosToX0Map);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -543,8 +545,9 @@ void StitchingCosmicRayMergingTool::OrderPfoMerges(const PfoToLArTPCMap &pfoToLA
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void StitchingCosmicRayMergingTool::StitchPfos(const MasterAlgorithm *const pAlgorithm, const ThreeDPointingClusterMap &pointingClusterMap,
-    const PfoMergeMap &pfoMerges, PfoToLArTPCMap &pfoToLArTPCMap, PfoToFloatMap &stitchedPfosToX0Map) const
+void StitchingCosmicRayMergingTool::StitchPfos(const Algorithm *const pAlgorithm, const StitchingPfoOperations *const pStitchingOperations,
+    const ThreeDPointingClusterMap &pointingClusterMap, const PfoMergeMap &pfoMerges, PfoToLArTPCMap &pfoToLArTPCMap,
+    PfoToFloatMap &stitchedPfosToX0Map) const
 {
     PfoVector pfoVectorToEnlarge;
     for (const auto &mapEntry : pfoMerges)
@@ -590,7 +593,7 @@ void StitchingCosmicRayMergingTool::StitchPfos(const MasterAlgorithm *const pAlg
                 if (std::find(shiftedPfos.begin(), shiftedPfos.end(), pPfoI) == shiftedPfos.end())
                 {
                     if (!m_useXcoordinate || m_alwaysApplyT0Calculation)
-                        this->ShiftPfo(pAlgorithm, pPfoI, pPfoJ, x0, pfoToLArTPCMap, pfoToPointingVertexMatrix);
+                        this->ShiftPfo(pAlgorithm, pStitchingOperations, pPfoI, pPfoJ, x0, pfoToLArTPCMap, pfoToPointingVertexMatrix);
 
                     shiftedPfos.insert(pPfoI);
                 }
@@ -598,7 +601,7 @@ void StitchingCosmicRayMergingTool::StitchPfos(const MasterAlgorithm *const pAlg
                 if (std::find(shiftedPfos.begin(), shiftedPfos.end(), pPfoJ) == shiftedPfos.end())
                 {
                     if (!m_useXcoordinate || m_alwaysApplyT0Calculation)
-                        this->ShiftPfo(pAlgorithm, pPfoJ, pPfoI, x0, pfoToLArTPCMap, pfoToPointingVertexMatrix);
+                        this->ShiftPfo(pAlgorithm, pStitchingOperations, pPfoJ, pPfoI, x0, pfoToLArTPCMap, pfoToPointingVertexMatrix);
 
                     shiftedPfos.insert(pPfoJ);
                 }
@@ -611,7 +614,7 @@ void StitchingCosmicRayMergingTool::StitchPfos(const MasterAlgorithm *const pAlg
             if (pPfoToDelete == pPfoToEnlarge)
                 continue;
 
-            pAlgorithm->StitchPfos(pPfoToEnlarge, pPfoToDelete, pfoToLArTPCMap);
+            pStitchingOperations->StitchPfos(pPfoToEnlarge, pPfoToDelete, pfoToLArTPCMap);
         }
 
         stitchedPfosToX0Map.insert(PfoToFloatMap::value_type(pPfoToEnlarge, x0));
@@ -620,9 +623,9 @@ void StitchingCosmicRayMergingTool::StitchPfos(const MasterAlgorithm *const pAlg
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void StitchingCosmicRayMergingTool::ShiftPfo(const MasterAlgorithm *const pAlgorithm, const ParticleFlowObject *const pPfoToShift,
-    const ParticleFlowObject *const pMatchedPfo, const float x0, const PfoToLArTPCMap &pfoToLArTPCMap,
-    const PfoToPointingVertexMatrix &pfoToPointingVertexMatrix) const
+void StitchingCosmicRayMergingTool::ShiftPfo(const Algorithm *const pAlgorithm, const StitchingPfoOperations *const pStitchingOperations,
+    const ParticleFlowObject *const pPfoToShift, const ParticleFlowObject *const pMatchedPfo, const float x0,
+    const PfoToLArTPCMap &pfoToLArTPCMap, const PfoToPointingVertexMatrix &pfoToPointingVertexMatrix) const
 {
     // get stitching vertex for the pfo to be shifted
     const PfoToPointingVertexMatrix::const_iterator pfoToPointingVertexMatrixIter(pfoToPointingVertexMatrix.find(pPfoToShift));
@@ -661,7 +664,7 @@ void StitchingCosmicRayMergingTool::ShiftPfo(const MasterAlgorithm *const pAlgor
 
     const float signedX0(std::fabs(x0) * positionShiftSign);
 
-    pAlgorithm->ShiftPfoHierarchy(pPfoToShift, pfoToLArTPCMap, signedX0);
+    pStitchingOperations->ShiftPfoHierarchy(pPfoToShift, pfoToLArTPCMap, signedX0);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.cc
@@ -1,5 +1,5 @@
 /**
- *  @file   LArContent/src/LArControlFlow/StitchingCosmicRayMergingTool.cc
+ *  @file   LArContent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.cc
  *
  *  @brief  Implementation of the stitching cosmic ray merging tool class.
  *
@@ -15,7 +15,7 @@
 
 #include "larpandoracontent/LArObjects/LArThreeDSlidingFitResult.h"
 
-#include "larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.h"
+#include "larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.h"
 
 using namespace pandora;
 

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.h
@@ -1,5 +1,5 @@
 /**
- *  @file   LArContent/include/LArControlFlow/StitchingCosmicRayMergingTool.h
+ *  @file   LArContent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.h
  *
  *  @brief  Header file for the stitching cosmic ray merging tool class.
  *
@@ -9,7 +9,7 @@
 #define LAR_STITCHING_COSMIC_RAY_MERGING_TOOL_H 1
 
 #include "larpandoracontent/LArControlFlow/MasterAlgorithm.h"
-#include "larpandoracontent/LArControlFlow/StitchingBaseTool.h"
+#include "larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingBaseTool.h"
 
 #include "larpandoracontent/LArObjects/LArPointingCluster.h"
 

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.h
@@ -88,13 +88,13 @@ private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
     /**
-     *  @brief  Select primary Pfos from the input list of Pfos
+     *  @brief  Select Pfos from the input list of Pfos
      *
      *  @param  pInputPfoList the input list of Pfos
      *  @param  pfoToLArTPCMap the input mapping between Pfos and tpc
      *  @param  outputPfoList the output list of Pfos
      */
-    void SelectPrimaryPfos(const pandora::PfoList *pInputPfoList, const PfoToLArTPCMap &pfoToLArTPCMap, pandora::PfoList &outputPfoList) const;
+    void SelectPfos(const pandora::PfoList *pInputPfoList, const PfoToLArTPCMap &pfoToLArTPCMap, pandora::PfoList &outputPfoList) const;
 
     typedef std::unordered_map<const pandora::ParticleFlowObject *, LArPointingCluster> ThreeDPointingClusterMap;
 
@@ -244,6 +244,7 @@ private:
     unsigned int m_minNCaloHits3D;
     float m_maxX0FractionalDeviation; ///< The maximum allowed fractional difference of an X0 contribution for matches to be stitched
     float m_boundaryToleranceWidth;   ///< The distance from the APA/CPA boundary inside which the deviation consideration is ignored
+    bool  m_onlyFinalStatePfos;       ///< Select only final state PFOs
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingCosmicRayMergingTool.h
@@ -8,8 +8,8 @@
 #ifndef LAR_STITCHING_COSMIC_RAY_MERGING_TOOL_H
 #define LAR_STITCHING_COSMIC_RAY_MERGING_TOOL_H 1
 
-#include "larpandoracontent/LArControlFlow/MasterAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingBaseTool.h"
+#include "larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingPfoOperations.h"
 
 #include "larpandoracontent/LArObjects/LArPointingCluster.h"
 
@@ -29,8 +29,8 @@ public:
      */
     StitchingCosmicRayMergingTool();
 
-    void Run(const MasterAlgorithm *const pAlgorithm, const pandora::PfoList *const pMultiPfoList, PfoToLArTPCMap &pfoToLArTPCMap,
-        PfoToFloatMap &stitchedPfosToX0Map);
+    void RunStitching(const pandora::Algorithm *const pAlgorithm, const StitchingPfoOperations *const pStitchingOperations,
+        const pandora::PfoList *const pMultiPfoList, PfoToLArTPCMap &pfoToLArTPCMap, PfoToFloatMap &stitchedPfosToX0Map) override;
 
     /**
      *  @brief  PfoAssociation class
@@ -196,8 +196,9 @@ private:
      *  @param  pfoToLArTPCMap the pfo to lar tpc map
      *  @param  stitchedPfosToX0Map a map of cosmic-ray pfos that have been stitched between lar tpcs to the X0 shift
      */
-    void StitchPfos(const MasterAlgorithm *const pAlgorithm, const ThreeDPointingClusterMap &pointingClusterMap,
-        const PfoMergeMap &pfoMerges, PfoToLArTPCMap &pfoToLArTPCMap, PfoToFloatMap &stitchedPfosToX0Map) const;
+    void StitchPfos(const pandora::Algorithm *const pAlgorithm, const StitchingPfoOperations *const pStitchingOperations,
+        const ThreeDPointingClusterMap &pointingClusterMap, const PfoMergeMap &pfoMerges, PfoToLArTPCMap &pfoToLArTPCMap,
+        PfoToFloatMap &stitchedPfosToX0Map) const;
 
     typedef std::unordered_map<const pandora::ParticleFlowObject *, LArPointingCluster::Vertex> PfoToPointingVertexMap;
     typedef std::unordered_map<const pandora::ParticleFlowObject *, PfoToPointingVertexMap> PfoToPointingVertexMatrix;
@@ -211,9 +212,9 @@ private:
      *  @param  pfoToLArTPCMap the pfo to lar tpc map
      *  @param  pfoToPointingVertexMatrix the map [pfo -> map [matched pfo -> pfo stitching vertex]]
      */
-    void ShiftPfo(const MasterAlgorithm *const pAlgorithm, const pandora::ParticleFlowObject *const pPfoToShift,
-        const pandora::ParticleFlowObject *const pMatchedPfo, const float x0, const PfoToLArTPCMap &pfoToLArTPCMap,
-        const PfoToPointingVertexMatrix &pfoToPointingVertexMatrix) const;
+    void ShiftPfo(const pandora::Algorithm *const pAlgorithm, const StitchingPfoOperations *const pStitchingOperations,
+        const pandora::ParticleFlowObject *const pPfoToShift, const pandora::ParticleFlowObject *const pMatchedPfo, const float x0,
+        const PfoToLArTPCMap &pfoToLArTPCMap, const PfoToPointingVertexMatrix &pfoToPointingVertexMatrix) const;
 
     /**
      *  @brief  Calculate x0 shift for a group of associated Pfos

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingPfoOperations.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingPfoOperations.h
@@ -15,14 +15,15 @@
 namespace lar_content
 {
 
-typedef std::unordered_map<const pandora::ParticleFlowObject *, const pandora::LArTPC *> PfoToLArTPCMap;
-
 /**
  *  @brief  StitchingPfoOperations class
  */
 class StitchingPfoOperations
 {
 public:
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, const pandora::LArTPC *> PfoToLArTPCMap;
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, float> PfoToFloatMap;
+
     virtual ~StitchingPfoOperations() = default;
 
     /**

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingPfoOperations.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingPfoOperations.h
@@ -28,8 +28,8 @@ public:
     /**
      *  @brief  Shift a Pfo hierarchy by a specified x0 value
      *
-     *  @param  pPfo the address of the parent pfo
-     *  @param  stitchingInfo  the source for additional, local, stitching information
+     *  @param  pParentPfo the address of the parent pfo
+     *  @param  pfoToLArTPCMap the pfo to lar tpc map
      *  @param  x0 the x0 correction relative to the input pfo
      */
     virtual void ShiftPfoHierarchy(const pandora::ParticleFlowObject *const pParentPfo, const PfoToLArTPCMap &pfoToLArTPCMap,

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingPfoOperations.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingPfoOperations.h
@@ -1,0 +1,51 @@
+/**
+ *  @file   larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingPfoOperations.h
+ *
+ *  @brief  Header file for the stitching pfo operations interface class.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_STITCHING_PFO_OPERATIONS_H
+#define LAR_STITCHING_PFO_OPERATIONS_H 1
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include <unordered_map>
+
+namespace lar_content
+{
+
+typedef std::unordered_map<const pandora::ParticleFlowObject *, const pandora::LArTPC *> PfoToLArTPCMap;
+
+/**
+ *  @brief  StitchingPfoOperations class
+ */
+class StitchingPfoOperations
+{
+public:
+    virtual ~StitchingPfoOperations() = default;
+
+    /**
+     *  @brief  Shift a Pfo hierarchy by a specified x0 value
+     *
+     *  @param  pPfo the address of the parent pfo
+     *  @param  stitchingInfo  the source for additional, local, stitching information
+     *  @param  x0 the x0 correction relative to the input pfo
+     */
+    virtual void ShiftPfoHierarchy(const pandora::ParticleFlowObject *const pParentPfo, const PfoToLArTPCMap &pfoToLArTPCMap,
+        const float x0) const = 0;
+
+    /**
+     *  @brief  Stitch together a pair of pfos
+     *
+     *  @param  pPfoToEnlarge the address of the pfo to enlarge
+     *  @param  pPfoToDelete the address of the pfo to delete (will become a dangling pointer)
+     *  @param  pfoToLArTPCMap the pfo to lar tpc map
+     */
+    virtual void StitchPfos(const pandora::ParticleFlowObject *const pPfoToEnlarge, const pandora::ParticleFlowObject *const pPfoToDelete,
+        PfoToLArTPCMap &pfoToLArTPCMap) const = 0;
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_STITCHING_PFO_OPERATIONS_H

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/TrackPfoStitchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/TrackPfoStitchingAlgorithm.cc
@@ -242,7 +242,7 @@ void TrackPfoStitchingAlgorithm::StitchPfos(
     for (const ParticleFlowObject *const pDaughterPfo : daughterPfos)
     {
         PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=,
-            PandoraContentApi::SetPfoParentDaughterRelationship(*this, pPfoToDelete, pDaughterPfo));
+            PandoraContentApi::SetPfoParentDaughterRelationship(*this, pPfoToEnlarge, pDaughterPfo));
     }
 
     for (const Vertex *const pDaughterVertex : daughterVertices)

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/TrackPfoStitchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/TrackPfoStitchingAlgorithm.cc
@@ -1,0 +1,299 @@
+/**
+ *  @file   larpandoracontent/LArThreeDReco/LArPfoStitching/TrackPfoStitchingAlgorithm.cc
+ *
+ *  @brief  Implementation of the track pfo stitching algorithm class.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "Geometry/DetectorGap.h"
+#include "Geometry/LArTPC.h"
+
+#include "larpandoracontent/LArThreeDReco/LArPfoStitching/TrackPfoStitchingAlgorithm.h"
+
+#include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArPfoHelper.h"
+#include "larpandoracontent/LArObjects/LArCaloHit.h"
+#include "larpandoracontent/LArUtility/PfoMopUpBaseAlgorithm.h"
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+TrackPfoStitchingAlgorithm::InferredLArTPC::InferredLArTPC(const PandoraApi::Geometry::LArTPC::Parameters &parameters) :
+    LArTPC(parameters)
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+TrackPfoStitchingAlgorithm::TrackPfoStitchingAlgorithm() :
+    m_visualise{false}
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode TrackPfoStitchingAlgorithm::Run()
+{
+    PANDORA_RETURN_IF(STATUS_CODE_SUCCESS, m_stitchingToolVector.empty());
+
+    const PfoList *pPfoList{nullptr};
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_inputPfoListName, pPfoList));
+
+    InferredLArTPCVector inferredTPCs;
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->InferLArTPCs(inferredTPCs));
+    if (inferredTPCs.size() == 1) // Might be in a per-TPC worker
+        return STATUS_CODE_SUCCESS;
+
+    PfoToLArTPCMap pfoToLArTPCMap;
+    this->GetPfoToLArTPCMap(pPfoList, inferredTPCs, pfoToLArTPCMap);
+    if (pfoToLArTPCMap.empty())
+        return STATUS_CODE_SUCCESS;
+
+    PfoToFloatMap stitchedPfosToX0Map;
+    for (StitchingBaseTool *const pStitchingTool : m_stitchingToolVector)
+        pStitchingTool->Run(this, pPfoList, pfoToLArTPCMap, stitchedPfosToX0Map);
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode TrackPfoStitchingAlgorithm::InferLArTPCs(InferredLArTPCVector &inferredTPCs) const
+{
+    const LArTPC &parentLArTPC(this->GetPandora().GetGeometry()->GetLArTPC());
+    const float parentMinX(parentLArTPC.GetCenterX() - 0.5f * parentLArTPC.GetWidthX());
+    const float parentMaxX(parentLArTPC.GetCenterX() + 0.5f * parentLArTPC.GetWidthX());
+
+    std::vector<std::pair<float, float>> driftGapXIntervals;
+    for (const DetectorGap *const pDetectorGap : this->GetPandora().GetGeometry()->GetDetectorGapList())
+    {
+        const LineGap *const pLineGap(dynamic_cast<const LineGap *>(pDetectorGap));
+
+        if (!pLineGap || (pLineGap->GetLineGapType() != TPC_DRIFT_GAP))
+            continue;
+
+        PANDORA_RETURN_IF(STATUS_CODE_INVALID_PARAMETER,
+            pLineGap->GetLineStartX() > pLineGap->GetLineEndX() ||
+            pLineGap->GetLineStartX() < parentMinX || pLineGap->GetLineEndX() > parentMaxX);
+        driftGapXIntervals.emplace_back(pLineGap->GetLineStartX(), pLineGap->GetLineEndX());
+    }
+
+    std::sort(driftGapXIntervals.begin(), driftGapXIntervals.end(),
+        [](const std::pair<float, float> &lhs, const std::pair<float, float> &rhs) { return lhs.first < rhs.first; });
+
+    std::vector<std::pair<float, float>> inferredTPCXIntervals;
+    float inferredTPCMinX{parentMinX};
+    for (const std::pair<float, float> &interval : driftGapXIntervals)
+    {
+        inferredTPCXIntervals.emplace_back(inferredTPCMinX, interval.first);
+        inferredTPCMinX = interval.second;
+    }
+    inferredTPCXIntervals.emplace_back(inferredTPCMinX, parentMaxX);
+
+    unsigned int volumeId{0};
+    bool isDriftInPositiveX{true};
+    for (const std::pair<float, float> &interval : inferredTPCXIntervals)
+    {
+        PandoraApi::Geometry::LArTPC::Parameters parameters;
+        parameters.m_larTPCVolumeId = volumeId++;
+        parameters.m_centerX = 0.5f * (interval.first + interval.second);
+        parameters.m_centerY = parentLArTPC.GetCenterY();
+        parameters.m_centerZ = parentLArTPC.GetCenterZ();
+        parameters.m_widthX = interval.second - interval.first;
+        parameters.m_widthY = parentLArTPC.GetWidthY();
+        parameters.m_widthZ = parentLArTPC.GetWidthZ();
+        parameters.m_wirePitchU = parentLArTPC.GetWirePitchU();
+        parameters.m_wirePitchV = parentLArTPC.GetWirePitchV();
+        parameters.m_wirePitchW = parentLArTPC.GetWirePitchW();
+        parameters.m_wireAngleU = parentLArTPC.GetWireAngleU();
+        parameters.m_wireAngleV = parentLArTPC.GetWireAngleV();
+        parameters.m_wireAngleW = parentLArTPC.GetWireAngleW();
+        parameters.m_sigmaUVW = parentLArTPC.GetSigmaUVW();
+        parameters.m_isDriftInPositiveX = isDriftInPositiveX;
+        isDriftInPositiveX = !isDriftInPositiveX;
+
+        inferredTPCs.push_back(std::unique_ptr<InferredLArTPC>(new InferredLArTPC(parameters)));
+    }
+
+    PANDORA_RETURN_IF(STATUS_CODE_FAILURE, inferredTPCs.empty());
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void TrackPfoStitchingAlgorithm::GetPfoToLArTPCMap(const PfoList *const pPfoList, const InferredLArTPCVector &inferredTPCs,
+    PfoToLArTPCMap &pfoToLArTPCMap) const
+{
+    for (const ParticleFlowObject *const pPfo : *pPfoList)
+    {
+        if (!LArPfoHelper::IsTrack(pPfo) || LArPfoHelper::IsNeutrino(pPfo))
+            continue;
+
+        CartesianPointVector positions;
+        LArPfoHelper::GetCoordinateVector(pPfo, TPC_3D, positions);
+
+        const LArTPC *pLArTPC{nullptr};
+        for (const CartesianVector &pos : positions)
+        {
+            const LArTPC *pPosLArTPC{nullptr};
+            for (const std::unique_ptr<InferredLArTPC> &pInferredLArTPC : inferredTPCs)
+            {
+                const float minX{pInferredLArTPC->GetCenterX() - 0.5f * pInferredLArTPC->GetWidthX()};
+                const float maxX{pInferredLArTPC->GetCenterX() + 0.5f * pInferredLArTPC->GetWidthX()};
+
+                if (pos.GetX() >= minX && pos.GetX() <= maxX)
+                {
+                    pPosLArTPC = pInferredLArTPC.get();
+                    break;
+                }
+            }
+            if (!pPosLArTPC) // 3D hit ended up in a gap or outside detector, ignoring it
+                continue;
+
+            if (pLArTPC && pLArTPC != pPosLArTPC)
+            {
+                pLArTPC = nullptr;
+                break;
+            }
+
+            pLArTPC = pPosLArTPC;
+        }
+
+        if (pLArTPC) // The Pfo is within a single LArTPC
+            pfoToLArTPCMap.emplace(pPfo, pLArTPC);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const std::string TrackPfoStitchingAlgorithm::GetListName(const Cluster *const pCluster) const
+{
+    for (const std::string &listName : m_daughterListNames)
+    {
+        const ClusterList *pClusterList{nullptr};
+        if ((PandoraContentApi::GetList(*this, listName, pClusterList) == STATUS_CODE_SUCCESS) &&
+            (pClusterList->end() != std::find(pClusterList->begin(), pClusterList->end(), pCluster)))
+        {
+            return listName;
+        }
+    }
+
+    PANDORA_THROW(STATUS_CODE_NOT_FOUND);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const std::string TrackPfoStitchingAlgorithm::GetListName(const Vertex *const pVertex) const
+{
+    for (const std::string &listName : m_daughterListNames)
+    {
+        const VertexList *pVertexList{nullptr};
+        if ((PandoraContentApi::GetList(*this, listName, pVertexList) == STATUS_CODE_SUCCESS) &&
+            (pVertexList->end() != std::find(pVertexList->begin(), pVertexList->end(), pVertex)))
+        {
+            return listName;
+        }
+    }
+
+    PANDORA_THROW(STATUS_CODE_NOT_FOUND);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void TrackPfoStitchingAlgorithm::ShiftPfoHierarchy([[maybe_unused]]const ParticleFlowObject *const pParentPfo,
+    [[maybe_unused]]const PfoToLArTPCMap &pfoToLArTPCMap, [[maybe_unused]]const float x0) const
+{
+    std::cout << "TrackPfoStitchingAlgorithm: Stitching tools must not be configured to apply an x0 correction" << std::endl;
+    PANDORA_THROW(STATUS_CODE_NOT_ALLOWED);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void TrackPfoStitchingAlgorithm::StitchPfos(
+    const ParticleFlowObject *const pPfoToEnlarge, const ParticleFlowObject *const pPfoToDelete, PfoToLArTPCMap &pfoToLArTPCMap) const
+{
+    PANDORA_THROW_IF(STATUS_CODE_NOT_ALLOWED, pPfoToEnlarge == pPfoToDelete);
+
+    if (m_visualise)
+    {
+        PfoList pfoToEnlargeList{pPfoToEnlarge};
+        PfoList pfoToDeleteList;
+        LArPfoHelper::GetAllDownstreamPfos(pPfoToDelete, pfoToDeleteList);
+        PANDORA_MONITORING_API(VisualizeParticleFlowObjects(this->GetPandora(), &pfoToEnlargeList, "PfoToEnlarge", GREEN, true, false));
+        PANDORA_MONITORING_API(VisualizeParticleFlowObjects(this->GetPandora(), &pfoToDeleteList, "PfoToDelete", RED, true, false));
+        PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
+    }
+
+    pfoToLArTPCMap.erase(pPfoToEnlarge);
+    pfoToLArTPCMap.erase(pPfoToDelete);
+
+    const PfoList daughterPfos(pPfoToDelete->GetDaughterPfoList());
+    const ClusterVector daughterClusters(pPfoToDelete->GetClusterList().begin(), pPfoToDelete->GetClusterList().end());
+    const VertexVector daughterVertices(pPfoToDelete->GetVertexList().begin(), pPfoToDelete->GetVertexList().end());
+
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Delete(*this, pPfoToDelete, m_inputPfoListName));
+
+    for (const ParticleFlowObject *const pDaughterPfo : daughterPfos)
+    {
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+            PandoraContentApi::SetPfoParentDaughterRelationship(*this, pPfoToDelete, pDaughterPfo));
+    }
+
+    for (const Vertex *const pDaughterVertex : daughterVertices)
+    {
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+            PandoraContentApi::Delete(*this, pDaughterVertex, this->GetListName(pDaughterVertex)));
+    }
+
+    for (const Cluster *const pDaughterCluster : daughterClusters)
+    {
+        const HitType daughterHitType(LArClusterHelper::GetClusterHitType(pDaughterCluster));
+        const Cluster *const pParentCluster(PfoMopUpBaseAlgorithm::GetParentCluster(pPfoToEnlarge->GetClusterList(), daughterHitType));
+
+        if (pParentCluster)
+        {
+            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+                PandoraContentApi::MergeAndDeleteClusters(
+                    *this, pParentCluster, pDaughterCluster, this->GetListName(pParentCluster), this->GetListName(pDaughterCluster)));
+        }
+        else
+        {
+            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::AddToPfo(*this, pPfoToEnlarge, pDaughterCluster));
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode TrackPfoStitchingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "InputPfoListName", m_inputPfoListName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadVectorOfValues(xmlHandle, "DaughterListNames", m_daughterListNames));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "Visualise", m_visualise));
+
+    AlgorithmToolVector algorithmToolVector;
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+        XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle, "StitchingTools", algorithmToolVector));
+
+    for (AlgorithmTool *const pAlgorithmTool : algorithmToolVector)
+    {
+        StitchingBaseTool *const pStitchingTool(dynamic_cast<StitchingBaseTool *>(pAlgorithmTool));
+
+        PANDORA_THROW_IF(STATUS_CODE_INVALID_PARAMETER, !pStitchingTool);
+
+        m_stitchingToolVector.push_back(pStitchingTool);
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArPfoStitching/TrackPfoStitchingAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoStitching/TrackPfoStitchingAlgorithm.h
@@ -1,0 +1,117 @@
+/**
+ *  @file   larpandoracontent/LArThreeDReco/LArPfoStitching/TrackPfoStitchingAlgorithm.h
+ *
+ *  @brief  Header file for the track pfo stitching algorithm class.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_TRACK_PFO_STITCHING_ALGORITHM_H
+#define LAR_TRACK_PFO_STITCHING_ALGORITHM_H 1
+
+#include "Pandora/Algorithm.h"
+#include "Api/PandoraApi.h"
+#include "Geometry/LArTPC.h"
+
+#include "larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingBaseTool.h"
+#include "larpandoracontent/LArThreeDReco/LArPfoStitching/StitchingPfoOperations.h"
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace lar_content
+{
+
+/**
+ *  @brief  TrackPfoStitchingAlgorithm class
+ */
+class TrackPfoStitchingAlgorithm : public pandora::Algorithm, public StitchingPfoOperations
+{
+public:
+    /**
+     *  @brief  Lightweight LArTPC used only by worker-side stitching
+     */
+    class InferredLArTPC : public pandora::LArTPC
+    {
+    public:
+        explicit InferredLArTPC(const PandoraApi::Geometry::LArTPC::Parameters &parameters);
+        ~InferredLArTPC() override = default;
+    };
+
+    /**
+     *  @brief  Default constructor
+     */
+    TrackPfoStitchingAlgorithm();
+
+    /**
+     *  @brief  Shift a Pfo hierarchy by a specified x0 value
+     *
+     *  @param  pParentPfo the address of the parent pfo
+     *  @param  pfoToLArTPCMap the pfo to lar tpc map
+     *  @param  x0 the x0 correction relative to the input pfo
+     */
+    void ShiftPfoHierarchy(const pandora::ParticleFlowObject *const pParentPfo, const PfoToLArTPCMap &pfoToLArTPCMap,
+        const float x0) const override;
+
+    /**
+     *  @brief  Stitch together a pair of pfos
+     *
+     *  @param  pPfoToEnlarge the address of the pfo to enlarge
+     *  @param  pPfoToDelete the address of the pfo to delete
+     *  @param  pfoToLArTPCMap the mapping between pfos and inferred tpcs
+     */
+    void StitchPfos(const pandora::ParticleFlowObject *const pPfoToEnlarge, const pandora::ParticleFlowObject *const pPfoToDelete,
+        PfoToLArTPCMap &pfoToLArTPCMap) const override;
+
+private:
+    typedef std::vector<StitchingBaseTool *> StitchingToolVector;
+    typedef std::vector<std::unique_ptr<InferredLArTPC>> InferredLArTPCVector;
+
+    pandora::StatusCode Run() override;
+
+    /**
+     *  @brief  Infer physical TPC volumes by removing drift-gap intervals from the worker TPC
+     *
+     *  @param[out]  inferredTPCs the inferred TPC objects
+     */
+    pandora::StatusCode InferLArTPCs(InferredLArTPCVector &inferredTPCs) const;
+
+    /**
+     *  @brief  Build a mapping of track pfos whose 3D hits originate from one physical TPC volume
+     *
+     *  @param[in]   pPfoList the input pfo list
+     *  @param[in]   inferredTPCs the inferred TPC objects
+     *  @param[out]  pfoToLArTPCMap the map of to inferred tpc
+     */
+    void GetPfoToLArTPCMap(
+        const pandora::PfoList *const pPfoList, const InferredLArTPCVector &inferredLArTPCs, PfoToLArTPCMap &pfoToLArTPCMap) const;
+
+    /**
+     *  @brief  Find the named list containing a cluster or vertex used by a pfo in the input list
+     *
+     *  @param[in]  pCluster the cluster whose list is required
+     *
+     *  @return the list name
+     */
+    const std::string GetListName(const pandora::Cluster *const pCluster) const;
+
+    /**
+     *  @brief  Find the named list containing a cluster or vertex used by a pfo in the input list
+     *
+     *  @param[in]  pVertex the vertex whose list is required
+     *
+     *  @return the list name
+     */
+    const std::string GetListName(const pandora::Vertex *const pVertex) const;
+
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle) override;
+
+    std::string m_inputPfoListName;            ///< The list containing pfos to stitch
+    pandora::StringVector m_daughterListNames; ///< Cluster and vertex lists used by the input pfos, updated when pfos are merged
+    StitchingToolVector m_stitchingToolVector; ///< The stitching tools to be applied
+    bool m_visualise;                          ///< Visualise merges
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_TRACK_PFO_STITCHING_ALGORITHM_H


### PR DESCRIPTION
Further cherry picks for changes SBND wants for Gen2 analyses which will use LArSoft v10_14_02_br in the same vein as PR #97 . These commits are waiting to be merged into PandoraPFA/LArContent and will then be marged into head of this repo. We want this gen2 SBND release promptly so jumping ahead and adding these now. 